### PR TITLE
Update ⚙ in tensor_formats.md for consistency

### DIFF
--- a/docs/src/guides/tensor_formats.md
+++ b/docs/src/guides/tensor_formats.md
@@ -87,7 +87,7 @@ some general descriptions.
 | SparsePoint          | Advanced | Single Sparse         | ✅                  | ✅            | ✅                        | ❌                  | ❌              | ✅     |
 | SparseInterval       | Advanced | Single Sparse Run     | ✅                  | ✅            | ✅                        | ❌                  | ❌              | ✅     |
 | SparseBand           | Advanced | Single Sparse Block   | ✅                  | ✅            | ✅                        | ❌                  | ❌              | ⚙️     |
-| DenseRLE             | Advanced | Dense Runs            | ✅                  | ❌            | ✅                        | ❌                  | ❌              | ⚙     |
+| DenseRLE             | Advanced | Dense Runs            | ✅                  | ❌            | ✅                        | ❌                  | ❌              | ⚙️     |
 | SparseBytemap        | Advanced | Sparse                | ✅                  | ✅            | ✅                        | ✅                  | ❌              | ✅     |
 | SparseDict           | Advanced | Sparse                | ✅                  | ✅            | ✅                        | ✅                  | ❌              | ✅️     |
 | AtomicLevel          | Modifier | No Data               | ✅                  | ✅            | ✅                        | ✅                  | ✅              | ⚙️ |


### PR DESCRIPTION
I noticed that there's that one gear icon that's different than the rest, so here's a one character diff pr :D
Also, the link in the about section seems to be outdated.