### PR TITLE
Wma/backwards fusion

### DIFF
--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -268,5 +268,3 @@ for (key, mtx) in [
     SUITE["parallel"]["SpMV_serial"][key] = @benchmarkable spmv_serial($A, $x)
     SUITE["parallel"]["SpMV_threaded"][key] = @benchmarkable spmv_threaded($A, $x)
 end
-
-SUITE = SUITE["high-level"]

--- a/src/interface/eager.jl
+++ b/src/interface/eager.jl
@@ -49,7 +49,7 @@ function Base.reduce(op::Function, bc::Broadcasted{FinchStyle{N}}; dims=:, init 
     end
 end
 
-function tensordot(A::AbstractTensor, B::AbstractTensor, idxs; kw...)
+function tensordot(A::Union{AbstractTensor, AbstractArray}, B::Union{AbstractTensor, AbstractArray}, idxs; kw...)
     compute(tensordot(lazy(A), lazy(B), idxs; kw...))
 end
 
@@ -78,6 +78,19 @@ Base.:*(
     y::AbstractTensor,
     z::Number...
 ) = map(*, y, x, z...)
+
+Base.:*(
+    A::AbstractTensor,
+    B::Union{AbstractTensor, AbstractArray}
+) = tensordot(A, B, (2, 1))
+Base.:*(
+    A::Union{AbstractTensor, AbstractArray},
+    B::AbstractTensor
+) = tensordot(A, B, (2, 1))
+Base.:*(
+    A::AbstractTensor,
+    B::AbstractTensor
+) = tensordot(A, B, (2, 1))
 
 Base.:-(x::AbstractTensor) = map(-, x)
 

--- a/src/interface/lazy.jl
+++ b/src/interface/lazy.jl
@@ -133,6 +133,9 @@ function Base.reduce(op, arg::LazyTensor{T, N}; dims=:, init = initial_value(op,
     LazyTensor{S}(identify(data), extrude, init)
 end
 
+tensordot(A::LazyTensor, B::Union{AbstractTensor, AbstractArray}, idxs; kwargs...) = tensordot(A, LazyTensor(B), idxs; kwargs...)
+tensordot(A::Union{AbstractTensor, AbstractArray}, B::LazyTensor, idxs; kwargs...) = tensordot(LazyTensor(A), B, idxs; kwargs...)
+
 # tensordot takes in two tensors `A` and `B` and performs a product and contraction
 function tensordot(A::LazyTensor{T1, N1}, B::LazyTensor{T2, N2}, idxs; mult_op=*, add_op=+, init = initial_value(add_op, return_type(DefaultAlgebra(), mult_op, T1, T2))) where {T1, T2, N1, N2}
     if idxs isa Number
@@ -271,6 +274,19 @@ Base.:*(
     y::LazyTensor,
     z::Number...
 ) = map(*, y, x, z...)
+
+Base.:*(
+    A::LazyTensor,
+    B::Union{LazyTensor, AbstractTensor, AbstractArray}
+) = tensordot(A, B, (2, 1))
+Base.:*(
+    A::Union{LazyTensor, AbstractTensor, AbstractArray},
+    B::LazyTensor
+) = tensordot(A, B, (2, 1))
+Base.:*(
+    A::LazyTensor,
+    B::LazyTensor
+) = tensordot(A, B, (2, 1))
 
 Base.:-(x::LazyTensor) = map(-, x)
 

--- a/test/test_issues.jl
+++ b/test/test_issues.jl
@@ -945,10 +945,29 @@ using SparseArrays
 
     #https://github.com/finch-tensor/Finch.jl/issues/615
 
-    A = Tensor(Dense(Dense(Element(0.0))), 10, 10)
-    res = sum(tensordot(A, A, ((1,), (2,))))
+    let
+        A = Tensor(Dense(Dense(Element(0.0))), 10, 10)
+        res = sum(tensordot(A, A, ((1,), (2,))))
 
-    A_lazy = Finch.LazyTensor(A)
-    res = sum(tensordot(A_lazy, A_lazy, ((1,), (2,))))  # fails
+        A_lazy = Finch.LazyTensor(A)
+        res = sum(tensordot(A_lazy, A_lazy, ((1,), (2,))))  # fails
+    end
+
+    #https://github.com/finch-tensor/Finch.jl/issues/614
+
+    let
+        A = sprand(5, 5, 0.5)
+        B = sprand(5, 5, 0.5)
+        x = rand(5)
+        C = Tensor(Dense(SparseList(Element(0.0))), A)
+        D = Tensor(Dense(SparseList(Element(0.0))), B)
+
+        @test A * B == C * D
+        @test A * B == compute(lazy(C) * D)
+        @test A * B == compute(C * lazy(D))
+        @test A * x == C * x
+        @test A * x == compute(lazy(C) * x)
+    end
+
 
 end


### PR DESCRIPTION
fixes #614

towards https://github.com/finch-tensor/finch-tensor-python/issues/76

fixes https://github.com/finch-tensor/finch-tensor-python/issues/24

In order to benchmark this effectively, I have also added support for matrix-matrix and matrix-vector multiply in Julia Finch with the `*` operator.

@hameerabbasi 
```
PkgBenchmark: benchmark results written to /Users/willow/Projects/Finch.jl/benchmark/result.json
  Benchmark Report for /Users/willow/Projects/Finch.jl
  ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡

  Job Properties
  ==============

    •  Time of benchmark: 25 Oct 2024 - 13:4

    •  Package commit: dirty

    •  Julia commit: 8f5b7c

    •  Julia command flags: None

    •  Environment variables: JULIA_NUM_THREADS => 8

  Results
  =======

  Below is a table of this job's results, obtained by running the benchmarks. The values listed in the ID column have the structure [parent_group, child_group, ..., key], and can be used to index into the BaseBenchmarks suite to retrieve the
  corresponding benchmarks. The percentages accompanying time and memory values in the below table are noise tolerances. The "true" time/memory value for a given benchmark is expected to fall within this percentage of the reported value. An
  empty cell means that the value was zero.

                                ID            time  GC time          memory allocations
  –––––––––––––––––––––––––––––––– ––––––––––––––– –––––––– ––––––––––––––– –––––––––––
         ["einsum_spmv_baremetal"]   4.791 ns (5%)                                     
     ["einsum_spmv_call_overhead"]  19.000 μs (5%)           17.48 KiB (1%)         421
  ["einsum_spmv_compile_overhead"] 264.286 ms (5%)          101.51 MiB (1%)     2618754
   ["permutedims(Dense(Dense()))"] 265.814 ms (5%) 9.460 ms 762.94 MiB (1%)         127
  ["permutedims(Dense(Sparse()))"]  78.293 ms (5%)          170.35 MiB (1%)         337
                   ["sddmm_fused"]   6.498 ms (5%)          264.80 KiB (1%)         708
                 ["sddmm_unfused"] 146.054 ms (5%)            7.89 MiB (1%)         849

  Benchmark Group List
  ====================

  Here's a list of all the benchmark groups executed by this job:

    •  []

  Julia versioninfo
  =================

  Julia Version 1.11.1
  Commit 8f5b7ca12ad (2024-10-16 10:53 UTC)
  Build Info:
    Official https://julialang.org/ release
  Platform Info:
    OS: macOS (arm64-apple-darwin22.4.0)
    uname: Darwin 23.5.0 Darwin Kernel Version 23.5.0: Wed May  1 20:14:38 PDT 2024; root:xnu-10063.121.3~5/RELEASE_ARM64_T6020 arm64 arm
    CPU: Apple M2 Max: 
                   speed         user         nice          sys         idle          irq
         #1-12  2400 MHz    9473315 s          0 s    4101236 s  149487093 s          0 s
    Memory: 32.0 GB (1745.5 MB free)
    Uptime: 1.0984676e7 sec
    Load Avg:  1.998046875  1.77197265625  1.72509765625
    WORD_SIZE: 64
    LLVM: libLLVM-16.0.6 (ORCJIT, apple-m2)
  Threads: 8 default, 0 interactive, 4 GC (on 8 virtual cores)
  ```