### PR TITLE
Kbd small finch logic changes

### DIFF
--- a/src/FinchLogic/nodes.jl
+++ b/src/FinchLogic/nodes.jl
@@ -205,6 +205,8 @@ function LogicNode(kind::LogicNodeKind, args::Vector)
         return LogicNode(kind, args[1], Any, LogicNode[])
     elseif kind === deferred && length(args) == 2
         return LogicNode(kind, args[1], args[2], LogicNode[])
+    elseif kind === deferred && length(args) == 3
+        return LogicNode(kind, (args[1], args[3]), args[2], LogicNode[])
     else
         args = LogicNode_concatenate_args(args)
         if (kind === table && length(args) >= 1) ||
@@ -231,7 +233,8 @@ end
 function Base.getproperty(node::LogicNode, sym::Symbol)
     if sym === :kind || sym === :val || sym === :type || sym === :children
         return Base.getfield(node, sym)
-    elseif node.kind === deferred && sym === :ex node.val
+    elseif node.kind === deferred && sym === :ex node.val isa Tuple ? node.val[1] : node.val[2]
+    elseif node.kind === deferred && sym === :imm node.val[2]
     elseif node.kind === field && sym === :name node.val::Symbol
     elseif node.kind === alias && sym === :name node.val::Symbol
     elseif node.kind === table && sym === :tns node.children[1]

--- a/src/FinchLogic/nodes.jl
+++ b/src/FinchLogic/nodes.jl
@@ -233,7 +233,7 @@ end
 function Base.getproperty(node::LogicNode, sym::Symbol)
     if sym === :kind || sym === :val || sym === :type || sym === :children
         return Base.getfield(node, sym)
-    elseif node.kind === deferred && sym === :ex node.val isa Tuple ? node.val[1] : node.val[2]
+    elseif node.kind === deferred && sym === :ex node.val isa Tuple ? node.val[1] : node.val
     elseif node.kind === deferred && sym === :imm node.val[2]
     elseif node.kind === field && sym === :name node.val::Symbol
     elseif node.kind === alias && sym === :name node.val::Symbol

--- a/src/FinchNotation/instances.jl
+++ b/src/FinchNotation/instances.jl
@@ -112,14 +112,11 @@ end
 
 function Base.show(io::IO, mime::MIME"text/plain", node::FinchNodeInstance)
     print(io, "Finch program instance")
-    show(io, Finch.striplines(finch_unparse_program(Finch.FinchCompiler(), node)))
-	#=
     if isstateful(node)
         display_statement(io, mime, node, 0)
     else
         display_expression(io, mime, node)
     end
-	=#
 end
 
 Base.:(==)(a::VariableInstance, b::VariableInstance) = false

--- a/src/FinchNotation/instances.jl
+++ b/src/FinchNotation/instances.jl
@@ -111,7 +111,7 @@ function Base.show(io::IO, node::FinchNodeInstance)
 end
 
 function Base.show(io::IO, mime::MIME"text/plain", node::FinchNodeInstance)
-    print(io, "Finch program instance")
+    print(io, "Finch program instance: ")
     if isstateful(node)
         display_statement(io, mime, node, 0)
     else

--- a/src/FinchNotation/nodes.jl
+++ b/src/FinchNotation/nodes.jl
@@ -329,7 +329,6 @@ end
 
 function Base.show(io::IO, mime::MIME"text/plain", node::FinchNode)
     print(io, "Finch program: ")
-    show(io, finch_unparse_program(JuliaContext(), node))
     if isstateful(node)
         display_statement(io, mime, node, 0)
     else

--- a/src/scheduler/LogicExecutor.jl
+++ b/src/scheduler/LogicExecutor.jl
@@ -6,7 +6,7 @@ is given as input to the program.
 """
 function defer_tables(ex, node::LogicNode)
     if @capture node table(~tns::isimmediate, ~idxs...)
-        table(deferred(:($ex.tns.val), typeof(tns.val)), map(enumerate(node.idxs)) do (i, idx)
+        table(deferred(:($ex.tns.val), typeof(tns.val), tns.val), map(enumerate(node.idxs)) do (i, idx)
             defer_tables(:($ex.idxs[$i]), idx)
         end)
     elseif istree(node)
@@ -29,7 +29,7 @@ function cache_deferred!(ctx, root::LogicNode)
         get!(seen, node.val) do
             var = freshen(ctx, :V)
             push_preamble!(ctx, :($var = $(node.ex)::$(node.type)))
-            deferred(var, node.type)
+            deferred(var, node.type, node.imm)
         end
     end))(root)
 end

--- a/test/test_interface.jl
+++ b/test/test_interface.jl
@@ -1,8 +1,19 @@
-using Finch: AsArray
+using Finch: AsArray, JuliaContext
+using Finch.FinchNotation: finch_unparse_program, @finch_program_instance
 
 @testset "interface" begin
 
     @info "Testing Finch Interface"
+
+    @testset "finch_unparse" begin
+        prgm = @finch_program quote 
+            A .= 0
+            for i = _
+                A[i] += 1
+            end
+        end
+        @test prgm.val == @finch_program $(finch_unparse_program(JuliaContext(), prgm))
+    end
 
     #https://github.com/finch-tensor/Finch.jl/issues/383
     let
@@ -814,4 +825,6 @@ using Finch: AsArray
         B = dropfills!(swizzle(A, 2, 1), [0.0 0.0 4.4; 1.1 0.0 0.0; 2.2 0.0 5.5; 3.3 0.0 0.0])
         @test B == swizzle(Tensor(Dense{Int64}(SparseList{Int64}(Element{0.0, Float64, Int64}([4.4, 1.1, 2.2, 5.5, 3.3]), 3, [1, 2, 3, 5, 6], [3, 1, 1, 3, 1]), 4)), 2, 1)
     end
+
+
 end


### PR DESCRIPTION
Builds on the de-parser #634 and makes some small changes to the deferred node. In particular, it includes the tensor instance in deferred so that optimizers can access the data to gather statistics.
 