### PR TITLE
Add missing data_repl_level for mutex_levels and separate_levels; Add atomic_element and mutex parallel spmv to the benchmark

### DIFF
--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -91,7 +91,7 @@ eval(let
     x = rand(1)
     y = rand(1)
     @finch_kernel function spmv(y, A, x)
-        for j=_, i=_
+        for j = _, i = _
             y[i] += A[i, j] * x[j]
         end
     end
@@ -120,7 +120,7 @@ C = Tensor(Dense(SparseList(Element(0.0))))
 
 @finch (C .= 0; for i=_, j=_, k=_; C[j, i] += A[k, i] * B[k, i] end)
 """
-cmd = pipeline(`$(Base.julia_cmd()) --project=$(Base.active_project()) --eval $code`, stdout = IOBuffer())
+cmd = pipeline(`$(Base.julia_cmd()) --project=$(Base.active_project()) --eval $code`, stdout=IOBuffer())
 
 SUITE["compile"]["time_to_first_SpGeMM"] = @benchmarkable run(cmd)
 
@@ -131,7 +131,11 @@ let
 
     SUITE["compile"]["compile_SpGeMM"] = @benchmarkable begin
         A, B, C = ($A, $B, $C)
-        Finch.execute_code(:ex, typeof(Finch.@finch_program_instance (C .= 0; for i=_, j=_, k=_; C[j, i] += A[k, i] * B[k, j] end; return C)))
+        Finch.execute_code(:ex, typeof(Finch.@finch_program_instance (C .= 0;
+        for i = _, j = _, k = _
+            C[j, i] += A[k, i] * B[k, j]
+        end;
+        return C)))
     end
 end
 
@@ -141,7 +145,11 @@ let
 
     SUITE["compile"]["compile_pretty_triangle"] = @benchmarkable begin
         A, c = ($A, $c)
-        @finch_code (c .= 0; for i=_, j=_, k=_; c[] += A[i, j] * A[j, k] * A[i, k] end; return c)
+        @finch_code (c .= 0;
+        for i = _, j = _, k = _
+            c[] += A[i, j] * A[j, k] * A[i, k]
+        end;
+        return c)
     end
 end
 
@@ -186,22 +194,28 @@ end
 SUITE["indices"] = BenchmarkGroup()
 
 function spmv32(A, x)
-    y = Tensor(Dense{Int32}(Element{0.0, Float64, Int32}()))
-    @finch (y .= 0; for i=_, j=_; y[i] += A[j, i] * x[j] end)
+    y = Tensor(Dense{Int32}(Element{0.0,Float64,Int32}()))
+    @finch (y .= 0;
+    for i = _, j = _
+        y[i] += A[j, i] * x[j]
+    end)
     return y
 end
 
 SUITE["indices"]["SpMV_32"] = BenchmarkGroup()
 for mtx in ["SNAP/soc-Epinions1"]#, "SNAP/soc-LiveJournal1"]
     A = SparseMatrixCSC(matrixdepot(mtx))
-    A = Tensor(Dense{Int32}(SparseList{Int32}(Element{0.0, Float64, Int32}())), A)
-    x = Tensor(Dense{Int32}(Element{0.0, Float64, Int32}()), rand(size(A)[2]))
+    A = Tensor(Dense{Int32}(SparseList{Int32}(Element{0.0,Float64,Int32}())), A)
+    x = Tensor(Dense{Int32}(Element{0.0,Float64,Int32}()), rand(size(A)[2]))
     SUITE["indices"]["SpMV_32"][mtx] = @benchmarkable spmv32($A, $x)
 end
 
 function spmv_p1(A, x)
     y = Tensor(Dense(Element(0.0)))
-    @finch (y .= 0; for i=_, j=_; y[i] += A[j, i] * x[j] end)
+    @finch (y .= 0;
+    for i = _, j = _
+        y[i] += A[j, i] * x[j]
+    end)
     return y
 end
 
@@ -217,27 +231,30 @@ for mtx in ["SNAP/soc-Epinions1"]#, "SNAP/soc-LiveJournal1"]
 end
 
 function spmv64(A, x)
-    y = Tensor(Dense{Int64}(Element{0.0, Float64, Int64}()))
-    @finch (y .= 0; for i=_, j=_; y[i] += A[j, i] * x[j] end)
+    y = Tensor(Dense{Int64}(Element{0.0,Float64,Int64}()))
+    @finch (y .= 0;
+    for i = _, j = _
+        y[i] += A[j, i] * x[j]
+    end)
     return y
 end
 
 SUITE["indices"]["SpMV_64"] = BenchmarkGroup()
 for mtx in ["SNAP/soc-Epinions1"]#, "SNAP/soc-LiveJournal1"]
     A = SparseMatrixCSC(matrixdepot(mtx))
-    A = Tensor(Dense{Int64}(SparseList{Int64}(Element{0.0, Float64, Int64}())), A)
-    x = Tensor(Dense{Int64}(Element{0.0, Float64, Int64}()), rand(size(A)[2]))
+    A = Tensor(Dense{Int64}(SparseList{Int64}(Element{0.0,Float64,Int64}())), A)
+    x = Tensor(Dense{Int64}(Element{0.0,Float64,Int64}()), rand(size(A)[2]))
     SUITE["indices"]["SpMV_64"][mtx] = @benchmarkable spmv64($A, $x)
 end
 
 SUITE["parallel"] = BenchmarkGroup()
 
 function spmv_serial(A, x)
-    y = Tensor(Dense{Int64}(Element{0.0, Float64}()))
+    y = Tensor(Dense{Int64}(Element{0.0,Float64}()))
     @finch begin
         y .= 0
-        for i=_
-            for j=_
+        for i = _
+            for j = _
                 y[i] += A[j, i] * x[j]
             end
         end
@@ -246,11 +263,11 @@ function spmv_serial(A, x)
 end
 
 function spmv_threaded(A, x)
-    y = Tensor(Dense{Int64}(Element{0.0, Float64}()))
+    y = Tensor(Dense{Int64}(Element{0.0,Float64}()))
     @finch begin
         y .= 0
-        for i=parallel(_)
-            for j=_
+        for i = parallel(_)
+            for j = _
                 y[i] += A[j, i] * x[j]
             end
         end
@@ -263,8 +280,8 @@ SUITE["parallel"]["SpMV_threaded"] = BenchmarkGroup()
 for (key, mtx) in [
     "SNAP/soc-Epinions1" => SparseMatrixCSC(matrixdepot("SNAP/soc-Epinions1")),
     "fsprand(10_000, 10_000, 0.01)" => fsprand(10_000, 10_000, 0.01)]
-    A = Tensor(Dense{Int64}(SparseList{Int64}(Element{0.0, Float64, Int64}())), mtx)
-    x = Tensor(Dense{Int64}(Element{0.0, Float64, Int64}()), rand(size(A)[2]))
+    A = Tensor(Dense{Int64}(SparseList{Int64}(Element{0.0,Float64,Int64}())), mtx)
+    x = Tensor(Dense{Int64}(Element{0.0,Float64,Int64}()), rand(size(A)[2]))
     SUITE["parallel"]["SpMV_serial"][key] = @benchmarkable spmv_serial($A, $x)
     SUITE["parallel"]["SpMV_threaded"][key] = @benchmarkable spmv_threaded($A, $x)
 end

--- a/src/tensors/levels/mutex_levels.jl
+++ b/src/tensors/levels/mutex_levels.jl
@@ -72,6 +72,8 @@ end
 @inline level_axes(lvl::MutexLevel{AVal,Lvl}) where {AVal,Lvl} = level_axes(lvl.lvl)
 @inline level_eltype(::Type{MutexLevel{AVal,Lvl}}) where {AVal,Lvl} = level_eltype(Lvl)
 @inline level_fill_value(::Type{<:MutexLevel{AVal,Lvl}}) where {AVal,Lvl} = level_fill_value(Lvl)
+data_rep_level(::Type{<:MutexLevel{AVal,Lvl}}) where {AVal,Lvl} = data_rep_level(Lvl)
+
 
 # FIXME: These.
 (fbr::Tensor{<:MutexLevel})() = SubFiber(fbr.lvl, 1)()

--- a/src/tensors/levels/mutex_levels.jl
+++ b/src/tensors/levels/mutex_levels.jl
@@ -1,4 +1,3 @@
-
 """
     MutexLevel{Val, Lvl}()
 
@@ -17,7 +16,7 @@ julia> tensor_tree(Tensor(Dense(Mutex(Element(0.0))), [1, 2, 3]))
       └─ 3.0
 ```
 """
-struct MutexLevel{AVal, Lvl} <: AbstractLevel
+struct MutexLevel{AVal,Lvl} <: AbstractLevel
     lvl::Lvl
     locks::AVal
 end
@@ -27,12 +26,12 @@ const Mutex = MutexLevel
 MutexLevel(lvl) = MutexLevel(lvl, Base.Threads.SpinLock[])
 #MutexLevel(lvl::Lvl, locks::AVal) where {Lvl, AVal} =
 #    MutexLevel{AVal, Lvl}(lvl, locks)
-Base.summary(::MutexLevel{AVal, Lvl}) where {Lvl, AVal} = "MutexLevel($(AVal), $(Lvl))"
+Base.summary(::MutexLevel{AVal,Lvl}) where {Lvl,AVal} = "MutexLevel($(AVal), $(Lvl))"
 
-similar_level(lvl::Mutex{AVal, Lvl}, fill_value, eltype::Type, dims...) where {Lvl, AVal} =
+similar_level(lvl::Mutex{AVal,Lvl}, fill_value, eltype::Type, dims...) where {Lvl,AVal} =
     MutexLevel(similar_level(lvl.lvl, fill_value, eltype, dims...))
 
-postype(::Type{<:MutexLevel{AVal, Lvl}}) where {Lvl, AVal} = postype(Lvl)
+postype(::Type{<:MutexLevel{AVal,Lvl}}) where {Lvl,AVal} = postype(Lvl)
 
 function moveto(lvl::MutexLevel, device)
     lvl_2 = moveto(lvl.lvl, device)
@@ -46,14 +45,14 @@ set_fill_value!(lvl::MutexLevel, init) = MutexLevel(set_fill_value!(lvl.lvl, ini
 Base.resize!(lvl::MutexLevel, dims...) = MutexLevel(resize!(lvl.lvl, dims...), lvl.locks)
 
 
-function Base.show(io::IO, lvl::MutexLevel{AVal, Lvl}) where {AVal, Lvl}
+function Base.show(io::IO, lvl::MutexLevel{AVal,Lvl}) where {AVal,Lvl}
     print(io, "Mutex(")
     if get(io, :compact, false)
         print(io, "…")
     else
         show(IOContext(io), lvl.lvl)
         print(io, ", ")
-        show(IOContext(io, :typeinfo=>AVal), lvl.locks)
+        show(IOContext(io, :typeinfo => AVal), lvl.locks)
     end
     print(io, ")")
 end
@@ -68,11 +67,11 @@ function labelled_children(fbr::SubFiber{<:MutexLevel})
 end
 
 
-@inline level_ndims(::Type{<:MutexLevel{AVal, Lvl}}) where {AVal, Lvl} = level_ndims(Lvl)
-@inline level_size(lvl::MutexLevel{AVal, Lvl}) where {AVal, Lvl} = level_size(lvl.lvl)
-@inline level_axes(lvl::MutexLevel{AVal, Lvl}) where {AVal, Lvl} = level_axes(lvl.lvl)
-@inline level_eltype(::Type{MutexLevel{AVal, Lvl}}) where {AVal, Lvl} = level_eltype(Lvl)
-@inline level_fill_value(::Type{<:MutexLevel{AVal, Lvl}}) where {AVal, Lvl} = level_fill_value(Lvl)
+@inline level_ndims(::Type{<:MutexLevel{AVal,Lvl}}) where {AVal,Lvl} = level_ndims(Lvl)
+@inline level_size(lvl::MutexLevel{AVal,Lvl}) where {AVal,Lvl} = level_size(lvl.lvl)
+@inline level_axes(lvl::MutexLevel{AVal,Lvl}) where {AVal,Lvl} = level_axes(lvl.lvl)
+@inline level_eltype(::Type{MutexLevel{AVal,Lvl}}) where {AVal,Lvl} = level_eltype(Lvl)
+@inline level_fill_value(::Type{<:MutexLevel{AVal,Lvl}}) where {AVal,Lvl} = level_fill_value(Lvl)
 
 # FIXME: These.
 (fbr::Tensor{<:MutexLevel})() = SubFiber(fbr.lvl, 1)()
@@ -92,9 +91,9 @@ mutable struct VirtualMutexLevel <: AbstractVirtualLevel
     AVal
     Lvl
 end
-postype(lvl:: MutexLevel) = postype(lvl.lvl)
+postype(lvl::MutexLevel) = postype(lvl.lvl)
 
-postype(lvl:: VirtualMutexLevel) = postype(lvl.lvl)
+postype(lvl::VirtualMutexLevel) = postype(lvl.lvl)
 
 is_level_injective(ctx, lvl::VirtualMutexLevel) = [is_level_injective(ctx, lvl.lvl)...]
 
@@ -110,17 +109,17 @@ end
 
 function lower(ctx::AbstractCompiler, lvl::VirtualMutexLevel, ::DefaultStyle)
     quote
-        $MutexLevel{$(lvl.AVal), $(lvl.Lvl)}($(ctx(lvl.lvl)), $(lvl.locks))
+        $MutexLevel{$(lvl.AVal),$(lvl.Lvl)}($(ctx(lvl.lvl)), $(lvl.locks))
     end
 end
 
-function virtualize(ctx, ex, ::Type{MutexLevel{AVal, Lvl}}, tag=:lvl) where {AVal, Lvl}
+function virtualize(ctx, ex, ::Type{MutexLevel{AVal,Lvl}}, tag=:lvl) where {AVal,Lvl}
     sym = freshen(ctx, tag)
     atomics = freshen(ctx, tag, :_locks)
     push_preamble!(ctx, quote
-            $sym = $ex
-            $atomics = $ex.locks
-        end)
+        $sym = $ex
+        $atomics = $ex.locks
+    end)
     lvl_2 = virtualize(ctx, :($sym.lvl), Lvl, sym)
     temp = VirtualMutexLevel(lvl_2, sym, atomics, typeof(level_fill_value(Lvl)), Val, AVal, Lvl)
     temp
@@ -144,11 +143,11 @@ function assemble_level!(ctx, lvl::VirtualMutexLevel, pos_start, pos_stop)
     idx = freshen(ctx, :idx)
     lockVal = freshen(ctx, :lock)
     push_preamble!(ctx, quote
-              Finch.resize_if_smaller!($(lvl.locks), $(ctx(pos_stop)))
-              @inbounds for $idx = $(ctx(pos_start)):$(ctx(pos_stop))
-                $(lvl.locks)[$idx] = Finch.make_lock(eltype($(lvl.AVal)))
-              end
-          end)
+        Finch.resize_if_smaller!($(lvl.locks), $(ctx(pos_stop)))
+        @inbounds for $idx = $(ctx(pos_start)):$(ctx(pos_stop))
+            $(lvl.locks)[$idx] = Finch.make_lock(eltype($(lvl.AVal)))
+        end
+    end)
     assemble_level!(ctx, lvl.lvl, pos_start, pos_stop)
 end
 
@@ -159,11 +158,11 @@ function reassemble_level!(ctx, lvl::VirtualMutexLevel, pos_start, pos_stop)
     idx = freshen(ctx, :idx)
     lockVal = freshen(ctx, :lock)
     push_preamble!(ctx, quote
-              Finch.resize_if_smaller!($lvl.locks, $(ctx(pos_stop)))
-              @inbounds for $idx = $(ctx(pos_start)):$(ctx(pos_stop))
-                $lvl.locks[$idx] = Finch.make_lock(eltype($(lvl.AVal)))
-              end
-          end)
+        Finch.resize_if_smaller!($lvl.locks, $(ctx(pos_stop)))
+        @inbounds for $idx = $(ctx(pos_start)):$(ctx(pos_stop))
+            $lvl.locks[$idx] = Finch.make_lock(eltype($(lvl.AVal)))
+        end
+    end)
     reassemble_level!(ctx, lvl.lvl, pos_start, pos_stop)
     lvl
 end
@@ -213,7 +212,7 @@ function unfurl(ctx, fbr::VirtualSubFiber{VirtualMutexLevel}, ext, mode::Updater
     lockVal = freshen(ctx, lvl.ex, :lockVal)
     dev = lower(ctx, virtual_get_device(ctx.code.task), DefaultStyle())
     push_preamble!(ctx, quote
-        $atomicData =  Finch.get_lock($dev, $(lvl.locks), $(ctx(pos)), eltype($(lvl.AVal)))
+        $atomicData = Finch.get_lock($dev, $(lvl.locks), $(ctx(pos)), eltype($(lvl.AVal)))
         $lockVal = Finch.aquire_lock!($dev, $atomicData)
     end)
     res = unfurl(ctx, VirtualSubFiber(lvl.lvl, pos), ext, mode, proto)
@@ -230,7 +229,7 @@ function unfurl(ctx, fbr::VirtualHollowSubFiber{VirtualMutexLevel}, ext, mode::U
     lockVal = freshen(ctx, lvl.ex, :lockVal)
     dev = lower(ctx, virtual_get_device(ctx.code.task), DefaultStyle())
     push_preamble!(ctx, quote
-        $atomicData =  Finch.get_lock($dev, $(lvl.locks), $(ctx(pos)), eltype($(lvl.AVal)))
+        $atomicData = Finch.get_lock($dev, $(lvl.locks), $(ctx(pos)), eltype($(lvl.AVal)))
         $lockVal = Finch.aquire_lock!($dev, $atomicData)
     end)
     res = unfurl(ctx, VirtualHollowSubFiber(lvl.lvl, pos, fbr.dirty), ext, mode, proto)
@@ -247,7 +246,7 @@ function lower_assign(ctx, fbr::VirtualSubFiber{VirtualMutexLevel}, mode::Update
     lockVal = freshen(ctx, lvl.ex, :lockVal)
     dev = lower(ctx, virtual_get_device(ctx.code.task), DefaultStyle())
     push_preamble!(ctx, quote
-        $atomicData =  Finch.get_lock($dev, $(lvl.locks), $(ctx(pos)), eltype($(lvl.AVal)))
+        $atomicData = Finch.get_lock($dev, $(lvl.locks), $(ctx(pos)), eltype($(lvl.AVal)))
         $lockVal = Finch.aquire_lock!($dev, $atomicData)
     end)
     res = lower_assign(ctx, VirtualSubFiber(lvl.lvl, pos), mode, op, rhs)
@@ -264,7 +263,7 @@ function lower_assign(ctx, fbr::VirtualHollowSubFiber{VirtualMutexLevel}, mode::
     lockVal = freshen(ctx, lvl.ex, :lockVal)
     dev = lower(ctx, virtual_get_device(ctx.code.task), DefaultStyle())
     push_preamble!(ctx, quote
-        $atomicData =  Finch.get_lock($dev, $(lvl.locks), $(ctx(pos)), eltype($(lvl.AVal)))
+        $atomicData = Finch.get_lock($dev, $(lvl.locks), $(ctx(pos)), eltype($(lvl.AVal)))
         $lockVal = Finch.aquire_lock!($dev, $atomicData)
     end)
     res = lower_assign(ctx, VirtualHollowSubFiber(lvl.lvl, pos, fbr.dirty), mode, op, rhs)

--- a/src/tensors/levels/separate_levels.jl
+++ b/src/tensors/levels/separate_levels.jl
@@ -71,6 +71,8 @@ end
 @inline level_axes(lvl::SeparateLevel{Lvl,Val}) where {Lvl,Val} = level_axes(lvl.lvl)
 @inline level_eltype(::Type{SeparateLevel{Lvl,Val}}) where {Lvl,Val} = level_eltype(Lvl)
 @inline level_fill_value(::Type{<:SeparateLevel{Lvl,Val}}) where {Lvl,Val} = level_fill_value(Lvl)
+data_rep_level(::Type{<:SeparateLevel{Lvl,Val}}) where {Lvl,Val} = data_rep_level(Lvl)
+
 
 function (fbr::SubFiber{<:SeparateLevel})(idxs...)
     q = fbr.pos

--- a/src/tensors/levels/separate_levels.jl
+++ b/src/tensors/levels/separate_levels.jl
@@ -18,7 +18,7 @@ julia> tensor_tree(Tensor(Dense(Separate(Element(0.0))), [1, 2, 3]))
       └─ 3.0
 ```
 """
-struct SeparateLevel{Lvl, Val} <: AbstractLevel
+struct SeparateLevel{Lvl,Val} <: AbstractLevel
     lvl::Lvl
     val::Val
 end
@@ -26,12 +26,12 @@ const Separate = SeparateLevel
 
 #similar_level(lvl, level_fill_value(typeof(lvl)), level_eltype(typeof(lvl)), level_size(lvl)...)
 SeparateLevel(lvl::Lvl) where {Lvl} = SeparateLevel(lvl, Lvl[])
-Base.summary(::Separate{Lvl, Val}) where {Lvl, Val} = "Separate($(Lvl))"
+Base.summary(::Separate{Lvl,Val}) where {Lvl,Val} = "Separate($(Lvl))"
 
-similar_level(lvl::Separate{Lvl, Val}, fill_value, eltype::Type, dims...) where {Lvl, Val} =
+similar_level(lvl::Separate{Lvl,Val}, fill_value, eltype::Type, dims...) where {Lvl,Val} =
     SeparateLevel(similar_level(lvl.lvl, fill_value, eltype, dims...))
 
-postype(::Type{<:Separate{Lvl, Val}}) where {Lvl, Val} = postype(Lvl)
+postype(::Type{<:Separate{Lvl,Val}}) where {Lvl,Val} = postype(Lvl)
 
 function moveto(lvl::SeparateLevel, device)
     lvl_2 = moveto(lvl.lvl, device)
@@ -40,11 +40,11 @@ function moveto(lvl::SeparateLevel, device)
 end
 
 pattern!(lvl::SeparateLevel) = SeparateLevel(pattern!(lvl.lvl), map(pattern!, lvl.val))
-set_fill_value!(lvl::SeparateLevel, init) = SeparateLevel(set_fill_value!(lvl.lvl, init), map(lvl_2->set_fill_value!(lvl_2, init), lvl.val))
-Base.resize!(lvl::SeparateLevel, dims...) = SeparateLevel(resize!(lvl.lvl, dims...), map(lvl_2->resize!(lvl_2, dims...), lvl.val))
+set_fill_value!(lvl::SeparateLevel, init) = SeparateLevel(set_fill_value!(lvl.lvl, init), map(lvl_2 -> set_fill_value!(lvl_2, init), lvl.val))
+Base.resize!(lvl::SeparateLevel, dims...) = SeparateLevel(resize!(lvl.lvl, dims...), map(lvl_2 -> resize!(lvl_2, dims...), lvl.val))
 
 
-function Base.show(io::IO, lvl::SeparateLevel{Lvl, Val}) where {Lvl, Val}
+function Base.show(io::IO, lvl::SeparateLevel{Lvl,Val}) where {Lvl,Val}
     print(io, "Separate(")
     if get(io, :compact, false)
         print(io, "…")
@@ -66,11 +66,11 @@ function labelled_children(fbr::SubFiber{<:SeparateLevel})
     [LabelledTree(SubFiber(lvl.val[pos], 1))]
 end
 
-@inline level_ndims(::Type{<:SeparateLevel{Lvl, Val}}) where {Lvl, Val} = level_ndims(Lvl)
-@inline level_size(lvl::SeparateLevel{Lvl, Val}) where {Lvl, Val} = level_size(lvl.lvl)
-@inline level_axes(lvl::SeparateLevel{Lvl, Val}) where {Lvl, Val} = level_axes(lvl.lvl)
-@inline level_eltype(::Type{SeparateLevel{Lvl, Val}}) where {Lvl, Val} = level_eltype(Lvl)
-@inline level_fill_value(::Type{<:SeparateLevel{Lvl, Val}}) where {Lvl, Val} = level_fill_value(Lvl)
+@inline level_ndims(::Type{<:SeparateLevel{Lvl,Val}}) where {Lvl,Val} = level_ndims(Lvl)
+@inline level_size(lvl::SeparateLevel{Lvl,Val}) where {Lvl,Val} = level_size(lvl.lvl)
+@inline level_axes(lvl::SeparateLevel{Lvl,Val}) where {Lvl,Val} = level_axes(lvl.lvl)
+@inline level_eltype(::Type{SeparateLevel{Lvl,Val}}) where {Lvl,Val} = level_eltype(Lvl)
+@inline level_fill_value(::Type{<:SeparateLevel{Lvl,Val}}) where {Lvl,Val} = level_fill_value(Lvl)
 
 function (fbr::SubFiber{<:SeparateLevel})(idxs...)
     q = fbr.pos
@@ -88,7 +88,7 @@ mutable struct VirtualSeparateLevel <: AbstractVirtualLevel
     Val
 end
 
-postype(lvl:: VirtualSeparateLevel) = postype(lvl.lvl)
+postype(lvl::VirtualSeparateLevel) = postype(lvl.lvl)
 
 is_level_injective(ctx, lvl::VirtualSeparateLevel) = [is_level_injective(ctx, lvl.lvl)..., true]
 function is_level_atomic(ctx, lvl::VirtualSeparateLevel)
@@ -102,17 +102,17 @@ end
 
 function lower(ctx::AbstractCompiler, lvl::VirtualSeparateLevel, ::DefaultStyle)
     quote
-        $SeparateLevel{$(lvl.Lvl), $(lvl.Val)}($(ctx(lvl.lvl)), $(lvl.val))
+        $SeparateLevel{$(lvl.Lvl),$(lvl.Val)}($(ctx(lvl.lvl)), $(lvl.val))
     end
 end
 
-function virtualize(ctx, ex, ::Type{SeparateLevel{Lvl, Val}}, tag=:lvl) where {Lvl, Val}
+function virtualize(ctx, ex, ::Type{SeparateLevel{Lvl,Val}}, tag=:lvl) where {Lvl,Val}
     sym = freshen(ctx, tag)
     val = freshen(ctx, tag, :_val)
 
     push_preamble!(ctx, quote
-              $sym = $ex
-              $val = $ex.val
+        $sym = $ex
+        $val = $ex.val
     end)
     lvl_2 = virtualize(ctx, :($ex.lvl), Lvl, sym)
     VirtualSeparateLevel(lvl_2, sym, val, typeof(level_fill_value(Lvl)), Lvl, Val)
@@ -130,12 +130,12 @@ function virtual_moveto_level(ctx, lvl::VirtualSeparateLevel, arch)
     # Need to move each pointer...
     val_2 = freshen(ctx, lvl.val)
     push_preamble!(ctx, quote
-              $val_2 = $(lvl.val)
-              $(lvl.val) = $moveto($(lvl.val), $(ctx(arch)))
-          end)
+        $val_2 = $(lvl.val)
+        $(lvl.val) = $moveto($(lvl.val), $(ctx(arch)))
+    end)
     push_epilogue!(ctx, quote
-              $(lvl.val) = $val_2
-          end)
+        $(lvl.val) = $val_2
+    end)
     virtual_moveto_level(ctx, lvl.lvl, arch)
 end
 
@@ -159,16 +159,18 @@ function assemble_level!(ctx, lvl::VirtualSeparateLevel, pos_start, pos_stop)
                 Finch.level_eltype(typeof($(lvl.ex).lvl)),
                 $(map(ctx, map(getstop, virtual_level_size(ctx, lvl)))...)
             )
-            $(contain(ctx) do ctx_2
-                lvl_2 = virtualize(ctx_2.code, sym, lvl.Lvl, sym)
-                lvl_2 = declare_level!(ctx_2, lvl_2, literal(0), literal(virtual_level_fill_value(lvl_2)))
-                lvl_2 = virtual_level_resize!(ctx_2, lvl_2, virtual_level_size(ctx_2, lvl.lvl)...)
-                push_preamble!(ctx_2, assemble_level!(ctx_2, lvl_2, literal(1), literal(1)))
-                contain(ctx_2) do ctx_3
-                    lvl_2 = freeze_level!(ctx_3, lvl_2, literal(1))
-                    :($(lvl.val)[$(ctx_3(pos))] = $(ctx_3(lvl_2)))
+            $(
+                contain(ctx) do ctx_2
+                    lvl_2 = virtualize(ctx_2.code, sym, lvl.Lvl, sym)
+                    lvl_2 = declare_level!(ctx_2, lvl_2, literal(0), literal(virtual_level_fill_value(lvl_2)))
+                    lvl_2 = virtual_level_resize!(ctx_2, lvl_2, virtual_level_size(ctx_2, lvl.lvl)...)
+                    push_preamble!(ctx_2, assemble_level!(ctx_2, lvl_2, literal(1), literal(1)))
+                    contain(ctx_2) do ctx_3
+                        lvl_2 = freeze_level!(ctx_3, lvl_2, literal(1))
+                        :($(lvl.val)[$(ctx_3(pos))] = $(ctx_3(lvl_2)))
+                    end
                 end
-            end)
+            )
         end
     end)
     lvl
@@ -181,15 +183,17 @@ function reassemble_level!(ctx, lvl::VirtualSeparateLevel, pos_start, pos_stop)
     pos = freshen(ctx, :pos)
     push_preamble!(ctx, quote
         for $idx in $(ctx(pos_start)):$(ctx(pos_stop))
-            $(contain(ctx) do ctx_2
-                lvl_2 = virtualize(ctx_2.code, :($(lvl.val)[$idx]), lvl.Lvl, sym)
-                push_preamble!(ctx_2, assemble_level!(ctx_2, lvl_2, literal(1), literal(1)))
-                lvl_2 = declare_level!(ctx_2, lvl_2, literal(1), init)
-                contain(ctx_2) do ctx_3
-                    lvl_2 = freeze_level!(ctx_3, lvl_2, literal(1))
-                    :($(lvl.val)[$(ctx_3(pos))] = $(ctx_3(lvl_2)))
+            $(
+                contain(ctx) do ctx_2
+                    lvl_2 = virtualize(ctx_2.code, :($(lvl.val)[$idx]), lvl.Lvl, sym)
+                    push_preamble!(ctx_2, assemble_level!(ctx_2, lvl_2, literal(1), literal(1)))
+                    lvl_2 = declare_level!(ctx_2, lvl_2, literal(1), init)
+                    contain(ctx_2) do ctx_3
+                        lvl_2 = freeze_level!(ctx_3, lvl_2, literal(1))
+                        :($(lvl.val)[$(ctx_3(pos))] = $(ctx_3(lvl_2)))
+                    end
                 end
-            end)
+            )
         end
     end)
     lvl
@@ -211,7 +215,7 @@ function instantiate(ctx, fbr::VirtualSubFiber{VirtualSeparateLevel}, mode::Read
     sym = freshen(ctx, :pointer_to_lvl)
     val = freshen(ctx, lvl.ex, :_val)
     return Thunk(
-        body = (ctx) -> begin
+        body=(ctx) -> begin
             lvl_2 = virtualize(ctx.code, :($(lvl.val)[$(ctx(pos))]), lvl.Lvl, sym)
             instantiate(ctx, VirtualSubFiber(lvl_2, literal(1)), mode)
         end,
@@ -224,7 +228,7 @@ function instantiate(ctx, fbr::VirtualSubFiber{VirtualSeparateLevel}, mode::Upda
     sym = freshen(ctx, :pointer_to_lvl)
 
     return Thunk(
-        body = (ctx) -> begin
+        body=(ctx) -> begin
             lvl_2 = virtualize(ctx.code, :($(lvl.val)[$(ctx(pos))]), lvl.Lvl, sym)
             lvl_2 = thaw_level!(ctx, lvl_2, literal(1))
             push_preamble!(ctx, assemble_level!(ctx, lvl_2, literal(1), literal(1)))
@@ -245,7 +249,7 @@ function instantiate(ctx, fbr::VirtualHollowSubFiber{VirtualSeparateLevel}, mode
     sym = freshen(ctx, :pointer_to_lvl)
 
     return Thunk(
-        body = (ctx) -> begin
+        body=(ctx) -> begin
             lvl_2 = virtualize(ctx.code, :($(lvl.val)[$(ctx(pos))]), lvl.Lvl, sym)
             lvl_2 = thaw_level!(ctx, lvl_2, literal(1))
             push_preamble!(ctx, assemble_level!(ctx, lvl_2, literal(1), literal(1)))
@@ -257,6 +261,6 @@ function instantiate(ctx, fbr::VirtualHollowSubFiber{VirtualSeparateLevel}, mode
                 end
             )
             res
-            end
-        )
-    end
+        end
+    )
+end


### PR DESCRIPTION
1. Add missing data_repl_level for mutex and separate in 
   - src/tensors/levels/mutex_levels.jl
   - src/tensors/levels/separate_levels.jl
2. Add spmv_atomic_element and spmv_mutex to the spmv parallel benchmark in 
   - benchmark/benchmarks.jl
  (spmv_atomic_element and spmv_mutex do not transpose A/x for parallel spmv)