### PR TITLE
Tensor Init Bug Fix

### DIFF
--- a/src/Galley/ExecutionEngine/execution-engine.jl
+++ b/src/Galley/ExecutionEngine/execution-engine.jl
@@ -143,8 +143,10 @@ function execute_query(alias_dict, q::PlanNode, verbose, cannonicalize, return_p
                                                                 |>  Finch.dataflow
                                                                 |>  Finch.unquote_literals)
     verbose >= 2 && println("Expected Output Size: $(estimate_nnz(agg_expr.stats))")
+
     if return_prgm
-        return :($output_name = $output_tensor), prgm_instance
+        output_tensor_init = tensor_initializer(output_formats, output_dimensions, output_default)
+        return :($output_name = $output_tensor_init), prgm_instance
     end
     start_time = time()
     Finch.execute(prgm_instance, mode=:fast)

--- a/src/Galley/PhysicalOptimizer/physical-optimizer.jl
+++ b/src/Galley/PhysicalOptimizer/physical-optimizer.jl
@@ -125,7 +125,7 @@ function logical_query_to_physical_queries(query::PlanNode, ST, alias_stats::Dic
 
     if !isnothing(output_order)
         for i in eachindex(output_order)
-            if i ∉ get_index_set(output_stats)
+            if output_order[i] ∉ get_index_set(output_stats)
                 add_dummy_idx!(output_stats, output_order[i])
             end
         end

--- a/src/Galley/PlanAST/plan.jl
+++ b/src/Galley/PlanAST/plan.jl
@@ -200,7 +200,7 @@ function Base.setproperty!(node::PlanNode, sym::Symbol, v)
     elseif node.kind === Query && sym === :expr node.children[2] = v
     elseif node.kind === Query && sym === :loop_order begin node.children = [node.name, node.expr, v...] end
     elseif node.kind === Outputs && sym === :names node.children = v
-    elseif node.kind === Plan && sym === :queries begin println([v...]); node.children = [v...] end
+    elseif node.kind === Plan && sym === :queries begin node.children = [v...] end
     else
         error("type PlanNode($(node.kind), ...) has no property $sym")
     end

--- a/src/Galley/utility-funcs.jl
+++ b/src/Galley/utility-funcs.jl
@@ -74,6 +74,24 @@ function initialize_tensor(formats, dims, default_value; copy_data = nothing, st
     end
 end
 
+function tensor_initializer(formats, dims, default_value)
+    B = :(Element($default_value))
+    for i in range(1, length(dims))
+        DT = get_dim_type(dims[i])
+        if formats[i] == t_sparse_list
+            B = :(SparseList($B, $(DT(dims[i]))))
+        elseif formats[i] == t_dense
+            B = :(Dense($B, $(DT(dims[i]))))
+        elseif formats[i] == t_bytemap
+            B = :(SparseByteMap($B, $(DT(dims[i]))))
+        elseif formats[i] == t_hash
+            B = :(SparseDict($B, $(DT(dims[i]))))
+        else
+            println("Error: Attempted to initialize invalid level format type.")
+        end
+    end
+    return :(Tensor($B))
+end
 
 # Generates a tensor whose non-default entries are distributed uniformly randomly throughout.
 function uniform_tensor(shape, sparsity; formats = [], default_value = 0, non_default_value = 1)


### PR DESCRIPTION
Galley's tensor initialization is improper, leading to memory leaks between invocations. 

This patch fixes that by updating the init to reference an expression rather than a tensor.