### PR TITLE
Kbd-loop-order-cost-model

### DIFF
--- a/src/Galley/PhysicalOptimizer/loop-ordering.jl
+++ b/src/Galley/PhysicalOptimizer/loop-ordering.jl
@@ -47,46 +47,12 @@ function get_reformat_set(input_stats::Vector{TensorStats}, prefix::Vector{Index
     return ref_set
 end
 
-# If output_vars is a vector, we assume that we will have to reindex it if it's just a set
-# prefix.
-function get_output_compat(output_vars::Vector{IndexExpr}, prefix::Vector{IndexExpr})
-    return if fully_compat_with_loop_prefix(output_vars, prefix)
-        FULL_PREFIX
-    elseif set_compat_with_loop_prefix(Set(output_vars), prefix)
-        SET_PREFIX
-    else
-        NO_PREFIX
-    end
-end
-
-# If output_vars is a set, we don't assume that we'll have to reindex it, so we treat any
-# prefix as a FULL_PREFIX.
-function get_output_compat(output_vars::Set{IndexExpr}, prefix::Vector{IndexExpr})
-    return if set_compat_with_loop_prefix(output_vars, prefix)
-        FULL_PREFIX
-    else
-        NO_PREFIX
-    end
-end
-
-
-@enum OUTPUT_COMPAT FULL_PREFIX=0 SET_PREFIX=1 NO_PREFIX=2
-PLAN_CLASS = Tuple{Set{IndexExpr}, OUTPUT_COMPAT, Set{Int}}
+PLAN_CLASS = Tuple{Set{IndexExpr}, Set{Int}}
 PLAN = Tuple{Vector{IndexExpr}, Float64}
 
 function cost_of_plan_class(pc::PLAN_CLASS, reformat_costs, output_size)
-    output_compat = pc[2]
-    rf_set = pc[3]
+    rf_set = pc[2]
     pc_cost = 0
-    if output_compat == FULL_PREFIX
-        pc_cost += output_size * SeqWriteCost
-    elseif output_compat == SET_PREFIX
-        pc_cost += output_size * SeqWriteCost
-    else
-        # Theoretically, this should be num_flops * RandomWriteCost, but we've seen that
-        # lead to aggressive transposing of inputs.
-        pc_cost += output_size * RandomWriteCost
-    end
     for i in rf_set
         pc_cost += reformat_costs[i]
     end
@@ -127,15 +93,14 @@ function get_join_loop_order_bounded(disjunct_and_conjunct_stats,
     # At all times, we keep track of the best plans for each level of output compatability.
     # This will let us consider the cost of random writes and transposes at the end.
     reformat_costs = Dict(i => cost_of_reformat(transposable_stats[i]) for i in eachindex(transposable_stats))
-    PLAN_CLASS = Tuple{Set{IndexExpr}, OUTPUT_COMPAT, Set{Int}}
+    PLAN_CLASS = Tuple{Set{IndexExpr}, Set{Int}}
     PLAN = Tuple{Vector{IndexExpr}, Float64}
     optimal_plans = Dict{PLAN_CLASS, PLAN}()
     for var in all_vars
         prefix = [var]
         rf_set = get_reformat_set(transposable_stats, prefix)
-        output_compat = get_output_compat(output_vars, prefix)
-        class = (Set(prefix), output_compat, rf_set)
-        cost = get_prefix_cost(prefix, conjunct_stats, disjunct_stats)
+        class = (Set(prefix), rf_set)
+        cost = get_prefix_cost(prefix, output_vars, conjunct_stats, disjunct_stats)
         optimal_plans[class] = (prefix, cost)
     end
 
@@ -155,7 +120,7 @@ function get_join_loop_order_bounded(disjunct_and_conjunct_stats,
             end
             potential_vars = setdiff(potential_vars, prefix_set)
             if length(potential_vars) == 0
-                # If the query isn't connected, we will need to include a cross product
+                # If the remaining query isn't connected, we will need to include a cross product
                 potential_vars = setdiff(all_vars, prefix_set)
             end
 
@@ -164,9 +129,8 @@ function get_join_loop_order_bounded(disjunct_and_conjunct_stats,
                 new_prefix = [prefix..., new_var]
 
                 rf_set = get_reformat_set(transposable_stats, new_prefix)
-                output_compat = get_output_compat(output_vars, new_prefix)
-                new_plan_class = (new_prefix_set, output_compat, rf_set)
-                new_cost = get_prefix_cost(new_prefix, conjunct_stats, disjunct_stats) + cost
+                new_plan_class = (new_prefix_set, rf_set)
+                new_cost = get_prefix_cost(new_prefix, output_vars, conjunct_stats, disjunct_stats) + cost
                 new_plan = (new_prefix, new_cost)
 
                 alt_cost = Inf
@@ -178,6 +142,7 @@ function get_join_loop_order_bounded(disjunct_and_conjunct_stats,
                 end
             end
         end
+
         plans_by_set = Dict()
         for (plan_class, plan) in new_plans
             idx_set = plan_class[1]
@@ -192,17 +157,15 @@ function get_join_loop_order_bounded(disjunct_and_conjunct_stats,
         undominated_plans = Dict()
         for (plan_class_1, plan_1) in new_plans
             cost_1 = plan_1[2]
-            output_compat_1 = plan_class_1[2]
-            reformat_set_1 = plan_class_1[3]
+            reformat_set_1 = plan_class_1[2]
             if cost_1 + cost_of_plan_class(plan_class_1, reformat_costs, output_size) > cost_bound
                 continue
             end
             is_dominated = false
             for (plan_class_2, plan_2) in plans_by_set[plan_class_1[1]]
                 cost_2 = plan_2[2]
-                output_compat_2 = plan_class_2[2]
-                reformat_set_2 = plan_class_2[3]
-                if cost_1 > cost_2 && output_compat_1 >= output_compat_2 && reformat_set_2 ⊆ reformat_set_1
+                reformat_set_2 = plan_class_2[2]
+                if cost_1 > cost_2 && reformat_set_2 ⊆ reformat_set_1
                     is_dominated = true
                     break
                 end

--- a/src/Galley/TensorStats/cost-estimates.jl
+++ b/src/Galley/TensorStats/cost-estimates.jl
@@ -64,10 +64,9 @@ function get_prefix_cost(new_prefix::Vector{IndexExpr},  output_vars, conjunct_s
         end
     end
 
-
     if output_vars isa Vector && new_var ∈ output_vars
         new_var_idx = only(indexin([new_var], output_vars))
-        min_var_idx = minimum([x for x in indexin(vars, output_vars) if !isnothing(x)])
+        min_var_idx = minimum([x for x in indexin(new_prefix, output_vars) if !isnothing(x)])
         is_rand_write = new_var_idx != min_var_idx
         if is_rand_write
             lookup_factor += RandomWriteCost

--- a/src/Galley/TensorStats/cost-estimates.jl
+++ b/src/Galley/TensorStats/cost-estimates.jl
@@ -35,22 +35,26 @@ end
 
 # The prefix cost is equal to the number of valid iterations times the number of tensors
 # which we need to access to handle that final iteration.
-function get_prefix_cost(new_var, vars::Set{IndexExpr},  conjunct_stats, disjunct_stats)
-    rel_conjuncts = [stat for stat in conjunct_stats if !isempty(get_index_set(stat) ∩ vars)]
-    rel_disjuncts = [stat for stat in disjunct_stats if !isempty(get_index_set(stat) ∩ vars)]
-    lookups = get_loop_lookups(vars, rel_conjuncts, rel_disjuncts)
+function get_prefix_cost(new_prefix::Vector{IndexExpr},  conjunct_stats, disjunct_stats)
+    new_var = new_prefix[end]
+    prefix_set = Set(new_prefix)
+    rel_conjuncts = [stat for stat in conjunct_stats if !isempty(get_index_set(stat) ∩ prefix_set)]
+    rel_disjuncts = [stat for stat in disjunct_stats if !isempty(get_index_set(stat) ∩ prefix_set)]
+    lookups = get_loop_lookups(prefix_set, rel_conjuncts, rel_disjuncts)
     lookup_factor = 0
     for stat in union(rel_conjuncts, rel_disjuncts)
         if new_var ∉ get_index_set(stat)
             continue
         end
-        if isnothing(get_index_formats(stat))
-            rel_vars = get_index_set(stat) ∩ vars
+        prev_lookup_factor = lookup_factor
+        if isnothing(get_index_order(stat)) || needs_reformat(stat, new_prefix)
+            rel_vars = get_index_set(stat) ∩ prefix_set
             approx_sparsity = estimate_nnz(stat; indices=rel_vars, conditional_indices=setdiff(rel_vars, [new_var])) / get_dim_size(stat, new_var)
-            is_dense = approx_sparsity > .01
+            is_dense = approx_sparsity > .05
             lookup_factor += is_dense ? SeqReadCost / 5 : SeqReadCost
             continue
         end
+
         format = get_index_format(stat, new_var)
         if format == t_dense
             lookup_factor += SeqReadCost / 5

--- a/src/Galley/TensorStats/cost-estimates.jl
+++ b/src/Galley/TensorStats/cost-estimates.jl
@@ -46,7 +46,6 @@ function get_prefix_cost(new_prefix::Vector{IndexExpr},  output_vars, conjunct_s
         if new_var ∉ get_index_set(stat)
             continue
         end
-        prev_lookup_factor = lookup_factor
         if isnothing(get_index_order(stat)) || needs_reformat(stat, new_prefix)
             rel_vars = get_index_set(stat) ∩ prefix_set
             approx_sparsity = estimate_nnz(stat; indices=rel_vars, conditional_indices=setdiff(rel_vars, [new_var])) / get_dim_size(stat, new_var)


### PR DESCRIPTION
This PR makes two changes to Galley's cost modeling for loop orders. 

1. It now considers whether an input needs to be transposed when determining its lookup factor. Consider an input A[i,j] that is stored sparse in i and dense in j. We associate a lower cost with lookup in the j dimension because dense lookups are cheap. However, if the loop order is i->j, we will need to transpose A. The resulting format will violate our assumption that j is dense, so it should no longer get the cheaper dense lookup factor.

2. It handles the cost of writing to the output in a less adhoc manner. Previously, we checked whether the output was a prefix of the loop order. If it was, we gave it a low cost-per-write and if not we gave it a high cost-per-write. This modeled the sequential vs random write strategy. However, it's a bit adhoc and a  better way to do it is to add a lookup factor for the output in the get_prefix_cost function.

Specifically, this arose from Mateusz triangle counting example.
```
using Finch
A = lazy(Tensor(Dense(SparseList(Element(0.0))), fsprand(50000, 50000, .001)))
compute(sum((A * A) .* A), ctx=galley_scheduler(verbose=true), tag=1)
```
Before this fix, it would transpose two of the inputs needlessly. Now it doesn't.
