### PR TITLE
Wma/benchmark improvements

### DIFF
--- a/benchmark/.gitignore
+++ b/benchmark/.gitignore
@@ -1,3 +1,4 @@
 Manifest.toml
 *.json
 *.o
+jl_*

--- a/benchmark/Project.toml
+++ b/benchmark/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+ArgParse = "c7e460c6-2fb9-53a9-8c5b-16f535851c63"
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 Finch = "9177782c-1635-4eb9-9bfb-d9dfa25e6bce"
 MatrixDepot = "b51810bb-c9f3-55da-ae3c-350fc1fbce05"

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -399,11 +399,9 @@ SUITE["structure"]["banded"]["SparseInterval"] = @benchmarkable spmv_serial($A2,
 
 if !isempty(parsed_args["include"])
     inc = reduce((a, b) -> :($a || $b), parsed_args["include"])
-    println(:(SUITE[@tagged $inc]))
     SUITE = eval(:(SUITE[@tagged $inc]))
 end
 if !isempty(parsed_args["exclude"])
     exc = reduce((a, b) -> :($a || $b), parsed_args["exclude"])
-    println(:(SUITE[@tagged !$exc]))
     SUITE = eval(:(SUITE[@tagged !$exc]))
 end

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -349,3 +349,7 @@ x = rand(N)
 SUITE["structure"]["banded"]["SparseList"] = @benchmarkable spmv_serial($A_ref, $x)
 SUITE["structure"]["banded"]["SparseBand"] = @benchmarkable spmv_serial($A, $x)
 SUITE["structure"]["banded"]["SparseInterval"] = @benchmarkable spmv_serial($A2, $x)
+
+if !isnothing(ENV["BENCHMARK_FILTER"])
+    SUITE = eval(:(SUITE[@tagged $(Meta.parse(ENV["BENCHMARK_FILTER"]))]))
+end

--- a/benchmark/runbenchmarks.jl
+++ b/benchmark/runbenchmarks.jl
@@ -11,7 +11,7 @@ end
 using PkgBenchmark
 benchmarkpkg(
     dirname(@__DIR__),
-    BenchmarkConfig(env = Dict("JULIA_NUM_THREADS" => "8")),
+    BenchmarkConfig(env = Dict("JULIA_NUM_THREADS" => "8", "FINCH_BENCHMARK_ARGS" => get(ENV, "FINCH_BENCHMARK_ARGS", join(ARGS, " ")))),
     resultfile = joinpath(@__DIR__, "result.json"),
 )
 

--- a/benchmark/runjudge.jl
+++ b/benchmark/runjudge.jl
@@ -14,16 +14,22 @@ function mkconfig(; kwargs...)
     return BenchmarkConfig(env = Dict("JULIA_NUM_THREADS" => "1"); kwargs...)
 end
 
+script = tempname(joinpath(@__DIR__))
+
+cp(joinpath(@__DIR__, "benchmarks.jl"), script)
+
 group_target = benchmarkpkg(
     dirname(@__DIR__),
     mkconfig(),
     resultfile = joinpath(@__DIR__, "result-target.json"),
+    script = script,
 )
 
 group_baseline = benchmarkpkg(
     dirname(@__DIR__),
     mkconfig(id = "main"),
     resultfile = joinpath(@__DIR__, "result-baseline.json"),
+    script = script,
 )
 
 judgement = judge(group_target, group_baseline)

--- a/benchmark/runjudge.jl
+++ b/benchmark/runjudge.jl
@@ -11,7 +11,7 @@ end
 using PkgBenchmark
 
 function mkconfig(; kwargs...)
-    return BenchmarkConfig(env = Dict("JULIA_NUM_THREADS" => "1"); kwargs...)
+    return BenchmarkConfig(env = Dict("JULIA_NUM_THREADS" => "1", "FINCH_BENCHMARK_ARGS" => get(ENV, "FINCH_BENCHMARK_ARGS", join(ARGS, " "))); kwargs...)
 end
 
 script = tempname(joinpath(@__DIR__))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,16 +19,20 @@ If the environment variable FINCH_TEST_ARGS is set, it will override the given a
     help = "overwrite reference output for $(Sys.WORD_SIZE)-bit systems"
     "--include", "-i"
     nargs = '*'
-    default = nothing
+    default = []
     help = "list of test suites to include, e.g., --include constructors merges"
 
     "--exclude", "-e"
     nargs = '*'
-    default = nothing
+    default = []
     help = "list of test suites to exclude, e.g., --exclude parallel algebra"
 end
 
-parsed_args = parse_args(get(ENV, "FINCH_TEST_ARGS", ARGS), s)
+if "FINCH_TEST_ARGS" in keys(ENV)
+    ARGS = split(ENV["FINCH_TEST_ARGS"], " ")
+end
+
+parsed_args = parse_args(ARGS, s)
 
 """
     check_output(fname, arg)
@@ -66,8 +70,8 @@ end
 function should_run(name)
     global parsed_args
     inc = parsed_args["include"]
-    exc = something(parsed_args["exclude"], [])
-    return (isnothing(inc) || !isempty(intersect(test_names, inc))) && isempty(intersect(test_names, exc))
+    exc = parsed_args["exclude"]
+    return (isempty(inc) || name in inc) && !(name in exc)
 end
 
 macro repl(io, ex, quiet = false)


### PR DESCRIPTION
adds the ability to filter benchmarks, adds galley to benchmarks, and fixes runjudge.jl to use the current benchmark script for both target and baseline. fixes #674