### PR TITLE
Update `propagate_map_queries`

### DIFF
--- a/src/scheduler/optimize.jl
+++ b/src/scheduler/optimize.jl
@@ -410,11 +410,11 @@ function propagate_map_queries(root)
             end
         end
     end
-    Rewrite(Prewalk(Chain([
+    root = Rewrite(Prewalk(Chain([
         (a -> if haskey(props, a) props[a] end),
         (@rule query(~a, ~b) => if haskey(props, a) plan() end),
-        (@rule plan(~a1..., plan(), ~a2...) => plan(a1..., a2...)),
     ])))(root)
+    Rewrite(Postwalk(@rule plan(~a1..., plan(), ~a2...) => plan(a1..., a2...)))(root)
 end
 
 function propagate_map_queries_backward(root)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -119,6 +119,7 @@ include("utils.jl")
         end
     end
     if should_run("parallel") include("test_parallel.jl") end
+    if should_run("scheduler") include("test_scheduler.jl") end
     #algebra goes at the end since it calls refresh()
     if should_run("algebra") include("test_algebra.jl") end
 end

--- a/test/test_scheduler.jl
+++ b/test/test_scheduler.jl
@@ -1,0 +1,34 @@
+@testset "scheduler" begin
+    @info "Testing Default Scheduler's Internals"
+
+    # test `propagate_map_queries`
+    let
+        plan = Finch.plan(
+            Finch.query(
+                Finch.alias(:A),
+                Finch.aggregate(
+                    Finch.immediate(:B),
+                    Finch.immediate(:C),
+                    Finch.immediate(:D),
+                )
+            ),
+            Finch.query(Finch.alias(:E), Finch.alias(:A)),
+            Finch.produces(Finch.alias(:E)),
+        )
+        expected = Finch.plan(
+            Finch.query(
+                Finch.alias(:E),
+                Finch.mapjoin(
+                    Finch.immediate(:B),
+                    Finch.immediate(:C),
+                    Finch.immediate(:D),
+                )
+            ),
+            Finch.produces(Finch.alias(:E)),
+        )
+
+        result = Finch.propagate_map_queries(plan)
+        @test result == expected
+    end
+
+end


### PR DESCRIPTION
Hi @willow-ahrens,

I started rewriting default scheduler (for now to Python) and I noticed that `propagate_map_queries` leaves empty plans after removing queries. Here's an example that reproduces it:
```julia
julia> plan = Finch.plan(Finch.query(Finch.alias(:A), Finch.aggregate(Finch.immediate(:B), Finch.immediate(:C), Finch.immediate(:D))), Finch.query(Finch.alias(:E), Finch.alias(:A)), Finch.produces(Finch.alias(:E)))
Finch Logic: plan
  A = aggregate(B, C, D)
  E = A
  return (E)
end

julia> res = Finch.propagate_map_queries(plan)
Finch Logic: plan
  plan
  end
  E = mapjoin(B, C, D)
  return (E)
end
```

It occurs because the third rule at the end of `propagate_map_queries` is never applied due to the Prewalk traversal - top level `Plan` is visited first so the empty/stub `Plan()` can't be removed.

My proposition is to make the third rule a separate `Rewrite`. WDYT?