### PR TITLE
Change type signature for `Base.:+` square args

### DIFF
--- a/src/interface/lazy.jl
+++ b/src/interface/lazy.jl
@@ -421,7 +421,7 @@ function Base.convert(T::Type{<:Number}, x::Square)
     return convert(T, root(x))
 end
 
-@inline function Base.:+(x::T, y::T) where {T<:Square}
+@inline function Base.:+(x::Square, y::Square)
     if x.scale < y.scale
         (x, y) = (y, x)
     end

--- a/test/suites/interface_tests.jl
+++ b/test/suites/interface_tests.jl
@@ -441,6 +441,15 @@ end
                 end
 
                 let
+                    A_ref = [1 2 0 4 0; 0 -2 1 0 1]
+                    A = swizzle(Tensor(Dense(SparseList(Element(0))), A_ref), 1, 2)
+
+                    @test norm(A, 1) == norm(A_ref, 1)
+                    @test norm(A, 2) == norm(A_ref, 2)
+                    @test norm(A, 3) == norm(A_ref, 3)
+                end
+
+                let
                     A = Tensor(
                         Dense(SparseList(Element(0.0))),
                         [0.0 0.0 4.4; 1.1 0.0 0.0; 2.2 0.0 5.5; 3.3 0.0 0.0],


### PR DESCRIPTION
Hi @willow-ahrens,

I noticed that for:

```julia
using Finch
using LinearAlgebra

A_ref = [1 2 0 4 0; 0 -2 1 0 1]
A = Tensor(Dense(SparseList(Element(0))), A_ref)
norm(A, 1) == norm(A_ref, 1)
norm(A, 2) == norm(A_ref, 2)  # fails
norm(A, 3) == norm(A_ref, 3)
```

the square option fails with an error:
```julia
ERROR: MethodError: no method matching +(::Finch.Square{Int64, Float64}, ::Finch.Square{Float64, Float64})

Closest candidates are:
  +(::Any, ::Any, ::Any, ::Any...)
   @ Base operators.jl:587
  +(::T, ::T) where T<:Finch.Square
   @ Finch ~/Finch.jl/src/interface/lazy.jl:424
```
This PR fixes it. 