### PR TITLE
fixes #726

### DIFF
--- a/.JuliaFormatter.toml
+++ b/.JuliaFormatter.toml
@@ -5,7 +5,3 @@ join_lines_based_on_source = true
 annotate_untyped_fields_with_any = false
 normalize_line_endings = "unix"
 always_use_return = false # https://github.com/domluna/JuliaFormatter.jl/issues/888
-align_assignment = true
-align_struct_field = true
-align_conditional = true
-align_pair_arrow = true

--- a/Project.toml
+++ b/Project.toml
@@ -56,6 +56,7 @@ TOML = "1.0"
 TensorMarket = "0.2"
 UUIDs = "1.4"
 UnsafeAtomics = "0.2.1, 0.3"
+JuliaFormatter = "1.0, 2"
 julia = "1.10"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -56,7 +56,7 @@ TOML = "1.0"
 TensorMarket = "0.2"
 UUIDs = "1.4"
 UnsafeAtomics = "0.2.1, 0.3"
-JuliaFormatter = "1.0, 2"
+JuliaFormatter = "1.0.62"
 julia = "1.10"
 
 [extras]

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -205,7 +205,8 @@ C = Tensor(Dense(SparseList(Element(0.0))))
 @finch (C .= 0; for i=_, j=_, k=_; C[j, i] += A[k, i] * B[k, i] end)
 """
 cmd = pipeline(
-    `$(Base.julia_cmd()) --project=$(Base.active_project()) --eval $code`; stdout=IOBuffer()
+    `$(Base.julia_cmd()) --project=$(Base.active_project()) --eval $code`;
+    stdout=IOBuffer(),
 )
 
 SUITE["compile"]["time_to_first_SpGeMM"] = @benchmarkable run(cmd)
@@ -220,13 +221,13 @@ let
         Finch.execute_code(
             :ex,
             typeof(
-                Finch.@finch_program_instance (
-                    C .= 0;
+                Finch.@finch_program_instance begin
+                    C .= 0
                     for i in _, j in _, k in _
                         C[j, i] += A[k, i] * B[k, j]
-                    end;
+                    end
                     return C
-                )
+                end
             ),
         )
     end
@@ -238,11 +239,13 @@ let
 
     SUITE["compile"]["compile_pretty_triangle"] = @benchmarkable begin
         A, c = ($A, $c)
-        @finch_code (c .= 0;
-        for i in _, j in _, k in _
-            c[] += A[i, j] * A[j, k] * A[i, k]
-        end;
-        return c)
+        @finch_code begin
+            c .= 0
+            for i in _, j in _, k in _
+                c[] += A[i, j] * A[j, k] * A[i, k]
+            end
+            return c
+        end
     end
 end
 
@@ -292,10 +295,12 @@ SUITE["indices"] = BenchmarkGroup()
 
 function spmv32(A, x)
     y = Tensor(Dense{Int32}(Element{0.0,Float64,Int32}()))
-    @finch (y .= 0;
-    for i in _, j in _
-        y[i] += A[j, i] * x[j]
-    end)
+    @finch begin
+        y .= 0
+        for i in _, j in _
+            y[i] += A[j, i] * x[j]
+        end
+    end
     return y
 end
 
@@ -309,10 +314,12 @@ end
 
 function spmv_p1(A, x)
     y = Tensor(Dense(Element(0.0)))
-    @finch (y .= 0;
-    for i in _, j in _
-        y[i] += A[j, i] * x[j]
-    end)
+    @finch begin
+        y .= 0
+        for i in _, j in _
+            y[i] += A[j, i] * x[j]
+        end
+    end
     return y
 end
 
@@ -336,10 +343,12 @@ end
 
 function spmv64(A, x)
     y = Tensor(Dense{Int64}(Element{0.0,Float64,Int64}()))
-    @finch (y .= 0;
-    for i in _, j in _
-        y[i] += A[j, i] * x[j]
-    end)
+    @finch begin
+        y .= 0
+        for i in _, j in _
+            y[i] += A[j, i] * x[j]
+        end
+    end
     return y
 end
 

--- a/docs/examples/pagerank.jl
+++ b/docs/examples/pagerank.jl
@@ -8,10 +8,12 @@ function pagerank(edges; nsteps=20, damp=0.85)
     (n, m) = size(edges)
     @assert n == m
     out_degree = Tensor(Dense(Element(0)))
-    @finch (out_degree .= 0;
-    for j in _, i in _
-        out_degree[j] += edges[i, j]
-    end)
+    @finch begin
+        out_degree .= 0
+        for j in _, i in _
+            out_degree[j] += edges[i, j]
+        end
+    end
     scaled_edges = Tensor(Dense(SparseList(Element(0.0))))
     @finch begin
         scaled_edges .= 0
@@ -22,22 +24,28 @@ function pagerank(edges; nsteps=20, damp=0.85)
         end
     end
     r = Tensor(Dense(Element(0.0)), n)
-    @finch (r .= 0.0;
-    for j in _
-        r[j] = 1.0 / n
-    end)
+    @finch begin
+        r .= 0.0
+        for j in _
+            r[j] = 1.0 / n
+        end
+    end
     rank = Tensor(Dense(Element(0.0)), n)
     beta_score = (1 - damp) / n
 
     for step in 1:nsteps
-        @finch (rank .= 0;
-        for j in _, i in _
-            rank[i] += scaled_edges[i, j] * r[j]
-        end)
-        @finch (r .= 0.0;
-        for i in _
-            r[i] = beta_score + damp * rank[i]
-        end)
+        @finch begin
+            rank .= 0
+            for j in _, i in _
+                rank[i] += scaled_edges[i, j] * r[j]
+            end
+        end
+        @finch begin
+            r .= 0.0
+            for i in _
+                r[i] = beta_score + damp * rank[i]
+            end
+        end
     end
     return r
 end

--- a/docs/examples/spgemm.jl
+++ b/docs/examples/spgemm.jl
@@ -3,18 +3,24 @@ function spgemm_inner(A, B)
     C = Tensor(Dense(SparseList(Element(z))))
     w = Tensor(SparseDict(SparseDict(Element(z))))
     AT = Tensor(Dense(SparseList(Element(z))))
-    @finch mode = :fast (w .= 0;
-    for k in _, i in _
-        w[k, i] = A[i, k]
-    end)
-    @finch mode = :fast (AT .= 0;
-    for i in _, k in _
-        AT[k, i] = w[k, i]
-    end)
-    @finch (C .= 0;
-    for j in _, i in _, k in _
-        C[i, j] += AT[k, i] * B[k, j]
-    end)
+    @finch mode = :fast begin
+        w .= 0
+        for k in _, i in _
+            w[k, i] = A[i, k]
+        end
+    end
+    @finch mode = :fast begin
+        AT .= 0
+        for i in _, k in _
+            AT[k, i] = w[k, i]
+        end
+    end
+    @finch begin
+        C .= 0
+        for j in _, i in _, k in _
+            C[i, j] += AT[k, i] * B[k, j]
+        end
+    end
     return C
 end
 
@@ -23,22 +29,30 @@ function spgemm_outer(A, B)
     C = Tensor(Dense(SparseList(Element(z))))
     w = Tensor(SparseDict(SparseDict(Element(z))))
     BT = Tensor(Dense(SparseList(Element(z))))
-    @finch mode = :fast (w .= 0;
-    for j in _, k in _
-        w[j, k] = B[k, j]
-    end)
-    @finch (BT .= 0;
-    for k in _, j in _
-        BT[j, k] = w[j, k]
-    end)
-    @finch (w .= 0;
-    for k in _, j in _, i in _
-        w[i, j] += A[i, k] * BT[j, k]
-    end)
-    @finch (C .= 0;
-    for j in _, i in _
-        C[i, j] = w[i, j]
-    end)
+    @finch mode = :fast begin
+        w .= 0
+        for j in _, k in _
+            w[j, k] = B[k, j]
+        end
+    end
+    @finch begin
+        BT .= 0
+        for k in _, j in _
+            BT[j, k] = w[j, k]
+        end
+    end
+    @finch begin
+        w .= 0
+        for k in _, j in _, i in _
+            w[i, j] += A[i, k] * BT[j, k]
+        end
+    end
+    @finch begin
+        C .= 0
+        for j in _, i in _
+            C[i, j] = w[i, j]
+        end
+    end
     return C
 end
 

--- a/docs/src/docs/internals/virtualization.md
+++ b/docs/src/docs/internals/virtualization.md
@@ -28,6 +28,7 @@ julia> @finch begin
                C[i] = A[i] * B[i]
            end
        end
+(C = Tensor(SparseList{Int64}(Element{0, Int64, Int64}([24, 45]), 5, [1, 3], [2, 5])),)
 
 julia> C
 5 Tensor{SparseListLevel{Int64, Vector{Int64}, Vector{Int64}, ElementLevel{0, Int64, Int64, Vector{Int64}}}}:
@@ -58,11 +59,13 @@ julia> Finch.regensym(Finch.striplines(@macroexpand @finch begin
            end
        end))
 quote
-    _res_1 = (Finch.execute)((Finch.FinchNotation.block_instance)((Finch.FinchNotation.block_instance)((Finch.FinchNotation.declare_instance)((Finch.FinchNotation.tag_instance)(variable_instance(:C), (Finch.FinchNotation.finch_leaf_instance)(C)), literal_instance(0), (Finch.FinchNotation.literal_instance)(Finch.auto)), begin
-                        let i = index_instance(i)
-                            (Finch.FinchNotation.loop_instance)(i, Finch.FinchNotation.Auto(), (Finch.FinchNotation.assign_instance)((Finch.FinchNotation.access_instance)((Finch.FinchNotation.tag_instance)(variable_instance(:C), (Finch.FinchNotation.finch_leaf_instance)(C)), (Finch.FinchNotation.updater_instance)((Finch.FinchNotation.literal_instance)((Finch.FinchNotation.initwrite)((Finch.fill_value)(C)))), (Finch.FinchNotation.tag_instance)(variable_instance(:i), (Finch.FinchNotation.finch_leaf_instance)(i))), (Finch.FinchNotation.literal_instance)((Finch.FinchNotation.initwrite)((Finch.fill_value)(C))), (Finch.FinchNotation.call_instance)((Finch.FinchNotation.tag_instance)(variable_instance(:*), (Finch.FinchNotation.finch_leaf_instance)(*)), (Finch.FinchNotation.access_instance)((Finch.FinchNotation.tag_instance)(variable_instance(:A), (Finch.FinchNotation.finch_leaf_instance)(A)), (Finch.FinchNotation.reader_instance)(), (Finch.FinchNotation.tag_instance)(variable_instance(:i), (Finch.FinchNotation.finch_leaf_instance)(i))), (Finch.FinchNotation.access_instance)((Finch.FinchNotation.tag_instance)(variable_instance(:B), (Finch.FinchNotation.finch_leaf_instance)(B)), (Finch.FinchNotation.reader_instance)(), (Finch.FinchNotation.tag_instance)(variable_instance(:i), (Finch.FinchNotation.finch_leaf_instance)(i))))))
-                        end
-                    end), (Finch.FinchNotation.yieldbind_instance)(variable_instance(:C))); )
+    _res_1 = (Finch.execute)(begin
+                (Finch.FinchNotation.block_instance)((Finch.FinchNotation.block_instance)((Finch.FinchNotation.declare_instance)((Finch.FinchNotation.tag_instance)(variable_instance(:C), (Finch.FinchNotation.finch_leaf_instance)(C)), literal_instance(0), (Finch.FinchNotation.literal_instance)(Finch.auto)), begin
+                            let i = index_instance(i)
+                                (Finch.FinchNotation.loop_instance)(i, Finch.FinchNotation.Auto(), (Finch.FinchNotation.assign_instance)((Finch.FinchNotation.access_instance)((Finch.FinchNotation.tag_instance)(variable_instance(:C), (Finch.FinchNotation.finch_leaf_instance)(C)), (Finch.FinchNotation.updater_instance)((Finch.FinchNotation.literal_instance)((initwrite)((fill_value)(C)))), (Finch.FinchNotation.tag_instance)(variable_instance(:i), (Finch.FinchNotation.finch_leaf_instance)(i))), (Finch.FinchNotation.literal_instance)((initwrite)((fill_value)(C))), (Finch.FinchNotation.call_instance)((Finch.FinchNotation.tag_instance)(variable_instance(:*), (Finch.FinchNotation.finch_leaf_instance)(*)), (Finch.FinchNotation.access_instance)((Finch.FinchNotation.tag_instance)(variable_instance(:A), (Finch.FinchNotation.finch_leaf_instance)(A)), (Finch.FinchNotation.reader_instance)(), (Finch.FinchNotation.tag_instance)(variable_instance(:i), (Finch.FinchNotation.finch_leaf_instance)(i))), (Finch.FinchNotation.access_instance)((Finch.FinchNotation.tag_instance)(variable_instance(:B), (Finch.FinchNotation.finch_leaf_instance)(B)), (Finch.FinchNotation.reader_instance)(), (Finch.FinchNotation.tag_instance)(variable_instance(:i), (Finch.FinchNotation.finch_leaf_instance)(i))))))
+                            end
+                        end), (Finch.FinchNotation.yieldbind_instance)(variable_instance(:C)))
+            end; )
     begin
         C = _res_1[:C]
     end

--- a/docs/src/docs/language/optimization_tips.md
+++ b/docs/src/docs/language/optimization_tips.md
@@ -180,11 +180,13 @@ A = Tensor(
     fsparse([2, 3, 4, 1, 3], [1, 1, 1, 3, 3], [1.1, 2.2, 3.3, 4.4, 5.5], (4, 3)),
 )
 B = Tensor(Dense(SparseList(Element(0.0)))) #DO NOT DO THIS, B has the wrong fill value
-@finch (B .= 0;
-for j in _, i in _
-    B[i, j] = A[i, j] + 1
-end;
-return B)
+@finch begin
+    B .= 0
+    for j in _, i in _
+        B[i, j] = A[i, j] + 1
+    end
+    return B
+end
 countstored(B)
 
 # output
@@ -200,11 +202,13 @@ A = Tensor(
     fsparse([2, 3, 4, 1, 3], [1, 1, 1, 3, 3], [1.1, 2.2, 3.3, 4.4, 5.5], (4, 3)),
 )
 B = Tensor(Dense(SparseList(Element(1.0))))
-@finch (B .= 1;
-for j in _, i in _
-    B[i, j] = A[i, j] + 1
-end;
-return B)
+@finch begin
+    B .= 1
+    for j in _, i in _
+        B[i, j] = A[i, j] + 1
+    end
+    return B
+end
 countstored(B)
 
 # output
@@ -225,11 +229,13 @@ A = Tensor(
 )
 B = Tensor(Dense(SparseList(Element(1.0))))
 x = 1 #DO NOT DO THIS, Finch cannot see the value of x anymore
-@finch (B .= 1;
-for j in _, i in _
-    B[i, j] = A[i, j] + x
-end;
-return B)
+@finch begin
+    B .= 1
+    for j in _, i in _
+        B[i, j] = A[i, j] + x
+    end
+    return B
+end
 countstored(B)
 
 # output
@@ -242,11 +248,13 @@ However, there are some situations where you may want a value to be dynamic. For
 ```julia
 function saxpy(x, a, y)
     z = Tensor(SparseList(Element(0.0)))
-    @finch (z .= 0;
-    for i in _
-        z[i] = a * x[i] + y[i]
-    end;
-    return z)
+    @finch begin
+        z .= 0
+        for i in _
+            z[i] = a * x[i] + y[i]
+        end
+        return z
+    end
 end
 ```
 
@@ -263,11 +271,13 @@ A = Tensor(
 B = ones(4, 3)
 C = Scalar(0.0)
 f(x, y) = x * y # DO NOT DO THIS, Obscures *
-@finch (C .= 0;
-for j in _, i in _
-    C[] += f(A[i, j], B[i, j])
-end;
-return C)
+@finch begin
+    C .= 0
+    for j in _, i in _
+        C[] += f(A[i, j], B[i, j])
+    end
+    return C
+end
 
 # output
 
@@ -277,11 +287,13 @@ return C)
 Checking the generated code, we see that this code is indeed densifying (notice the for-loop which repeatedly evaluates `f(B[i, j], 0.0)`).
 
 ```jldoctest example1
-@finch_code (C .= 0;
-for j in _, i in _
-    C[] += f(A[i, j], B[i, j])
-end;
-return C)
+@finch_code begin
+    C .= 0
+    for j in _, i in _
+        C[] += f(A[i, j], B[i, j])
+    end
+    return C
+end
 
 # output
 

--- a/src/FinchLogic/nodes.jl
+++ b/src/FinchLogic/nodes.jl
@@ -4,19 +4,19 @@ const ID = 4
 
 @enum LogicNodeKind begin
     immediate = 0ID
-    deferred  = 1ID
-    field     = 2ID
-    alias     = 3ID
-    table     = 4ID | IS_TREE
-    mapjoin   = 5ID | IS_TREE
+    deferred = 1ID
+    field = 2ID
+    alias = 3ID
+    table = 4ID | IS_TREE
+    mapjoin = 5ID | IS_TREE
     aggregate = 6ID | IS_TREE
-    reorder   = 7ID | IS_TREE
-    relabel   = 8ID | IS_TREE
-    reformat  = 9ID | IS_TREE
-    subquery  = 10ID | IS_TREE
-    query     = 11ID | IS_TREE | IS_STATEFUL
-    produces  = 12ID | IS_TREE | IS_STATEFUL
-    plan      = 13ID | IS_TREE | IS_STATEFUL
+    reorder = 7ID | IS_TREE
+    relabel = 8ID | IS_TREE
+    reformat = 9ID | IS_TREE
+    subquery = 10ID | IS_TREE
+    query = 11ID | IS_TREE | IS_STATEFUL
+    produces = 12ID | IS_TREE | IS_STATEFUL
+    plan = 13ID | IS_TREE | IS_STATEFUL
 end
 
 """

--- a/src/FinchLogic/nodes.jl
+++ b/src/FinchLogic/nodes.jl
@@ -75,7 +75,9 @@ aggregate
 
 Logical AST statement that reorders the dimensions of `arg` to be `idxs...`.
 Dimensions known to be length 1 may be dropped. Dimensions that do not exist in
-`arg` may be added.
+`arg` may be added. Dimensions added in this way are known as "extruded"
+dimensions. These dimensions have length 1, but may be broadcasted along
+dimensions which are not 1 in a mapjoin.
 """
 reorder
 
@@ -478,6 +480,46 @@ function propagate_fields(node::LogicNode, fields=Dict{LogicNode,Any}())
         similarterm(
             node, operation(node), map(x -> propagate_fields(x, fields), arguments(node))
         )
+    else
+        node
+    end
+end
+
+function getextrudes(ex, extrudes, fields)
+    if ex.kind === alias
+        return extrudes[ex]
+    elseif @capture ex table(~tns, ~idxs...)
+        return []
+    elseif @capture ex mapjoin(~f, ~args...)
+        return intersect(map(arg -> getextrudes(arg, extrudes, fields), args)...)
+    elseif @capture ex aggregate(~op, ~init, ~arg, ~idxs...)
+        return setdiff(getextrudes(arg, extrudes, fields), idxs)
+    elseif @capture ex reorder(~arg, ~idxs...)
+        idxs_2 = getfields(arg, fields)
+        exts_2 = getextrudes(arg, extrudes, fields)
+        return union(intersect(exts_2, idxs), setdiff(idxs, idxs_2))
+    elseif @capture ex relabel(~arg, ~idxs...)
+        idxs_2 = getfields(arg, fields)
+        reidx = Dict(map(Pair, idxs_2, idxs)...)
+        return map(idx -> reidx[idx], getextrudes(arg, extrudes, fields))
+    elseif @capture ex reformat(~tns, ~arg)
+        getextrudes(arg, extrudes, fields)
+    else
+        []
+    end
+end
+
+function propagate_extrudes(node::LogicNode, extrudes=Dict(), fields=Dict())
+    if @capture node plan(~stmts...)
+        stmts = map(stmts) do stmt
+            propagate_extrudes(stmt, extrudes)
+        end
+        plan(stmts...)
+    elseif @capture node query(~lhs, ~rhs)
+        extrudes[lhs] = compute_extrudes(rhs, extrudes)
+        fields[lhs] = getfields(rhs, fields)
+        #Rewrite(Postwalk(@rule ~a::isalias => )
+        node
     else
         node
     end

--- a/src/FinchNotation/nodes.jl
+++ b/src/FinchNotation/nodes.jl
@@ -4,25 +4,25 @@ const IS_CONST = 4
 const ID = 8
 
 @enum FinchNodeKind begin
-    literal   = 0ID | IS_CONST
-    value     = 1ID | IS_CONST
-    index     = 2ID
-    variable  = 3ID
-    virtual   = 4ID
-    tag       = 5ID | IS_TREE
-    call      = 6ID | IS_TREE
-    access    = 7ID | IS_TREE
-    reader    = 8ID | IS_TREE
-    updater   = 9ID | IS_TREE
-    cached    = 10ID | IS_TREE
-    assign    = 11ID | IS_TREE | IS_STATEFUL
-    loop      = 12ID | IS_TREE | IS_STATEFUL
-    sieve     = 13ID | IS_TREE | IS_STATEFUL
-    define    = 14ID | IS_TREE | IS_STATEFUL
-    declare   = 15ID | IS_TREE | IS_STATEFUL
-    thaw      = 16ID | IS_TREE | IS_STATEFUL
-    freeze    = 17ID | IS_TREE | IS_STATEFUL
-    block     = 18ID | IS_TREE | IS_STATEFUL
+    literal = 0ID | IS_CONST
+    value = 1ID | IS_CONST
+    index = 2ID
+    variable = 3ID
+    virtual = 4ID
+    tag = 5ID | IS_TREE
+    call = 6ID | IS_TREE
+    access = 7ID | IS_TREE
+    reader = 8ID | IS_TREE
+    updater = 9ID | IS_TREE
+    cached = 10ID | IS_TREE
+    assign = 11ID | IS_TREE | IS_STATEFUL
+    loop = 12ID | IS_TREE | IS_STATEFUL
+    sieve = 13ID | IS_TREE | IS_STATEFUL
+    define = 14ID | IS_TREE | IS_STATEFUL
+    declare = 15ID | IS_TREE | IS_STATEFUL
+    thaw = 16ID | IS_TREE | IS_STATEFUL
+    freeze = 17ID | IS_TREE | IS_STATEFUL
+    block = 18ID | IS_TREE | IS_STATEFUL
     yieldbind = 19ID | IS_TREE | IS_STATEFUL
 end
 

--- a/src/Galley/PlanAST/plan.jl
+++ b/src/Galley/PlanAST/plan.jl
@@ -6,16 +6,16 @@ const IS_STATEFUL = 2
 const ID = 4
 
 @enum PlanNodeKind begin
-    Value       = 1ID             #  Value(x::Any)
-    Index       = 2ID             #  Index(x::Union{String, Symbol})
-    Alias       = 3ID             #  Alias(x::Union{String, Symbol})
-    Input       = 4ID | IS_TREE   #  Input(tns::Union{Tensor, Number}, idxs...::{TI})
-    MapJoin     = 5ID | IS_TREE   #  MapJoin(op::Value, args..::PlanNode)
-    Aggregate   = 6ID | IS_TREE   #  Aggregate(op::Value, idxs...::Index, arg::PlanNode)
+    Value = 1ID             #  Value(x::Any)
+    Index = 2ID             #  Index(x::Union{String, Symbol})
+    Alias = 3ID             #  Alias(x::Union{String, Symbol})
+    Input = 4ID | IS_TREE   #  Input(tns::Union{Tensor, Number}, idxs...::{TI})
+    MapJoin = 5ID | IS_TREE   #  MapJoin(op::Value, args..::PlanNode)
+    Aggregate = 6ID | IS_TREE   #  Aggregate(op::Value, idxs...::Index, arg::PlanNode)
     Materialize = 7ID | IS_TREE   #  Materialize(formats::Vector{Formats}, idx_order::Vector{TI}, arg:PlanNode)
-    Query       = 8ID | IS_TREE   #  Query(name::Alias, expr::PlanNode)
-    Outputs     = 9ID | IS_TREE   #  Outputs(args...::TI)
-    Plan        = 10ID | IS_TREE   #  Plan(Queries..., Outputs)
+    Query = 8ID | IS_TREE   #  Query(name::Alias, expr::PlanNode)
+    Outputs = 9ID | IS_TREE   #  Outputs(args...::TI)
+    Plan = 10ID | IS_TREE   #  Plan(Queries..., Outputs)
 end
 Mat = Materialize
 Agg = Aggregate

--- a/src/abstract_tensor.jl
+++ b/src/abstract_tensor.jl
@@ -32,11 +32,13 @@ function freeze! end
 Thaw the read-only virtual tensor `tns` in the context `ctx` and return it. Afterwards,
 the tensor is update-only.
 """
-thaw!(ctx, tns) = throw(
-    FinchProtocolError(
-        "cannot modify $(typeof(tns)) in place (forgot to declare with .= ?)"
-    ),
-)
+function thaw!(ctx, tns)
+    throw(
+        FinchProtocolError(
+            "cannot modify $(typeof(tns)) in place (forgot to declare with .= ?)"
+        ),
+    )
+end
 
 """
     fill_value(arr)

--- a/src/execute.jl
+++ b/src/execute.jl
@@ -180,19 +180,19 @@ macro finch(opts_ex...)
         throw(ArgumentError("Expected at least one argument to @finch(opts..., ex)"))
     (opts, ex) = (opts_ex[1:(end - 1)], opts_ex[end])
     prgm = FinchNotation.finch_parse_instance(ex)
-    prgm = :(
-    $(FinchNotation.block_instance)(
-        $prgm,
-        $(FinchNotation.yieldbind_instance)(
-            $(
-                map(
-                    FinchNotation.variable_instance,
-                    FinchNotation.finch_parse_default_yieldbind(ex),
-                )...
+    prgm = quote
+        $(FinchNotation.block_instance)(
+            $prgm,
+            $(FinchNotation.yieldbind_instance)(
+                $(
+                    map(
+                        FinchNotation.variable_instance,
+                        FinchNotation.finch_parse_default_yieldbind(ex),
+                    )...
+                ),
             ),
-        ),
-    )
-)
+        )
+    end
     res = esc(:res)
     thunk = quote
         res = $execute($prgm, ; $(map(esc, opts)...))
@@ -229,19 +229,19 @@ macro finch_code(opts_ex...)
         throw(ArgumentError("Expected at least one argument to @finch(opts..., ex)"))
     (opts, ex) = (opts_ex[1:(end - 1)], opts_ex[end])
     prgm = FinchNotation.finch_parse_instance(ex)
-    prgm = :(
-    $(FinchNotation.block_instance)(
-        $prgm,
-        $(FinchNotation.yieldbind_instance)(
-            $(
-                map(
-                    FinchNotation.variable_instance,
-                    FinchNotation.finch_parse_default_yieldbind(ex),
-                )...
+    prgm = quote
+        $(FinchNotation.block_instance)(
+            $prgm,
+            $(FinchNotation.yieldbind_instance)(
+                $(
+                    map(
+                        FinchNotation.variable_instance,
+                        FinchNotation.finch_parse_default_yieldbind(ex),
+                    )...
+                ),
             ),
-        ),
-    )
-)
+        )
+    end
     return quote
         unquote_literals(
             dataflow(

--- a/src/interface/abstract_arrays.jl
+++ b/src/interface/abstract_arrays.jl
@@ -79,6 +79,7 @@ function unfurl(ctx, tns::VirtualAbstractArraySlice, ext, mode, proto)
             if length(idx_2) == arr.ndims
                 val = freshen(ctx, :val)
                 if mode.kind === reader
+                    #=We don't know what init is, but it won't be used here =#
                     Thunk(;
                         preamble=quote
                             $val = $(arr.data)[$(map(ctx, idx_2)...)]
@@ -89,9 +90,10 @@ function unfurl(ctx, tns::VirtualAbstractArraySlice, ext, mode, proto)
                                 nothing, nothing, arr.eltype, nothing, gensym(), val
                             ),
                             mode,
-                        ), #=We don't know what init is, but it won't be used here =#
+                        ),
                     )
                 else
+                    #=We don't know what init is, but it won't be used here =#
                     Thunk(;
                         body=(ctx,) -> instantiate(
                             ctx,
@@ -104,7 +106,7 @@ function unfurl(ctx, tns::VirtualAbstractArraySlice, ext, mode, proto)
                                 :($(arr.data)[$(map(ctx, idx_2)...)]),
                             ),
                             mode,
-                        ), #=We don't know what init is, but it won't be used here=#
+                        ),
                     )
                 end
             else
@@ -125,6 +127,7 @@ function instantiate(ctx::AbstractCompiler, arr::VirtualAbstractArray, mode)
     if arr.ndims == 0
         val = freshen(ctx, :val)
         if mode.kind === reader
+            #=We don't know what init is, but it won't be used here =#
             Thunk(;
                 preamble=quote
                     $val = $(arr.data)[]
@@ -133,9 +136,10 @@ function instantiate(ctx::AbstractCompiler, arr::VirtualAbstractArray, mode)
                     ctx,
                     VirtualScalar(nothing, nothing, arr.eltype, nothing, gensym(), val),
                     mode,
-                ), #=We don't know what init is, but it won't be used here =#
+                ),
             )
         else
+            #=We don't know what init is, but it won't be used here =#
             Thunk(;
                 body=(ctx,) -> instantiate(
                     ctx,
@@ -144,7 +148,7 @@ function instantiate(ctx::AbstractCompiler, arr::VirtualAbstractArray, mode)
                         :($(arr.data)[]),
                     ),
                     mode,
-                ), #=We don't know what init is, but it won't be used here=#
+                ),
             )
         end
     else
@@ -201,9 +205,9 @@ function Base.summary(io::IO, arr::AsArray)
     #summary(io, arr.fbr)
 end
 
-Base.size(arr::AsArray)                                            = size(arr.fbr)
-Base.getindex(arr::AsArray{T,N}, i::Vararg{Int,N}) where {T,N}     = arr.fbr[i...]
-Base.getindex(arr::AsArray{T,N}, i::Vararg{Any,N}) where {T,N}     = arr.fbr[i...]
+Base.size(arr::AsArray) = size(arr.fbr)
+Base.getindex(arr::AsArray{T,N}, i::Vararg{Int,N}) where {T,N} = arr.fbr[i...]
+Base.getindex(arr::AsArray{T,N}, i::Vararg{Any,N}) where {T,N} = arr.fbr[i...]
 Base.setindex!(arr::AsArray{T,N}, v, i::Vararg{Int,N}) where {T,N} = arr.fbr[i...] = v
 Base.setindex!(arr::AsArray{T,N}, v, i::Vararg{Any,N}) where {T,N} = arr.fbr[i...] = v
 

--- a/src/interface/lazy.jl
+++ b/src/interface/lazy.jl
@@ -393,9 +393,19 @@ Base.:*(
 
 Base.:-(x::LazyTensor) = map(-, x)
 
-Base.:-(x::LazyTensor, y::Union{LazyTensor,AbstractTensor,Base.AbstractArrayOrBroadcasted,Number}) = map(-, x, y)
-Base.:-(x::Union{LazyTensor,AbstractTensor,Base.AbstractArrayOrBroadcasted,Number}, y::LazyTensor) = map(-, x, y)
-Base.:-(x::LazyTensor, y::LazyTensor)                                                              = map(-, x, y)
+function Base.:-(
+    x::LazyTensor,
+    y::Union{LazyTensor,AbstractTensor,Base.AbstractArrayOrBroadcasted,Number},
+)
+    map(-, x, y)
+end
+function Base.:-(
+    x::Union{LazyTensor,AbstractTensor,Base.AbstractArrayOrBroadcasted,Number},
+    y::LazyTensor,
+)
+    map(-, x, y)
+end
+Base.:-(x::LazyTensor, y::LazyTensor) = map(-, x, y)
 
 Base.:/(x::LazyTensor, y::Number) = map(/, x, y)
 Base.:/(x::Number, y::LazyTensor) = map(\, y, x)

--- a/src/interface/traits.jl
+++ b/src/interface/traits.jl
@@ -465,13 +465,29 @@ rep_construct_hollow(fbr::RepeatData, protos) = Tensor(construct_level_rep(fbr, 
 rep_construct_hollow(fbr::SparseData, protos) = Tensor(construct_level_rep(fbr, protos...))
 rep_construct(fbr, protos) = Tensor(construct_level_rep(fbr, protos...))
 
-construct_level_rep(fbr::SparseData, proto::Union{Nothing,typeof(walk),typeof(extrude)}, protos...) = SparseDict(construct_level_rep(fbr.lvl, protos...))
-construct_level_rep(fbr::SparseData, proto::Union{typeof(laminate)}, protos...)                     = SparseDict(construct_level_rep(fbr.lvl, protos...))
-construct_level_rep(fbr::RepeatData, proto::Union{Nothing,typeof(walk),typeof(extrude)}, protos...) = SparseRunList(construct_level_rep(fbr.lvl, protos...))
-construct_level_rep(fbr::RepeatData, proto::Union{typeof(laminate)}, protos...)                     = SparseDict(construct_level_rep(fbr.lvl, protos...))
-construct_level_rep(fbr::DenseData, proto, protos...)                                               = Dense(construct_level_rep(fbr.lvl, protos...))
-construct_level_rep(fbr::ExtrudeData, proto, protos...)                                             = Dense(construct_level_rep(fbr.lvl, protos...), 1)
-construct_level_rep(fbr::ElementData)                                                               = Element{fbr.fill_value,fbr.eltype}()
+function construct_level_rep(
+    fbr::SparseData, proto::Union{Nothing,typeof(walk),typeof(extrude)}, protos...
+)
+    SparseDict(construct_level_rep(fbr.lvl, protos...))
+end
+function construct_level_rep(fbr::SparseData, proto::Union{typeof(laminate)}, protos...)
+    SparseDict(construct_level_rep(fbr.lvl, protos...))
+end
+function construct_level_rep(
+    fbr::RepeatData, proto::Union{Nothing,typeof(walk),typeof(extrude)}, protos...
+)
+    SparseRunList(construct_level_rep(fbr.lvl, protos...))
+end
+function construct_level_rep(fbr::RepeatData, proto::Union{typeof(laminate)}, protos...)
+    SparseDict(construct_level_rep(fbr.lvl, protos...))
+end
+function construct_level_rep(fbr::DenseData, proto, protos...)
+    Dense(construct_level_rep(fbr.lvl, protos...))
+end
+function construct_level_rep(fbr::ExtrudeData, proto, protos...)
+    Dense(construct_level_rep(fbr.lvl, protos...), 1)
+end
+construct_level_rep(fbr::ElementData) = Element{fbr.fill_value,fbr.eltype}()
 
 """
     fiber_ctr(tns, protos...)
@@ -492,12 +508,30 @@ fiber_ctr_hollow(fbr::SparseData, protos) = :(Tensor($(level_ctr(fbr, protos...)
 fiber_ctr_hollow(fbr::RepeatData, protos) = :(Tensor($(level_ctr(fbr, protos...))))
 fiber_ctr(fbr, protos) = :(Tensor($(level_ctr(fbr, protos...))))
 
-level_ctr(fbr::SparseData, proto::Union{Nothing,typeof(walk),typeof(extrude)}, protos...) = :(SparseDict($(level_ctr(fbr.lvl, protos...))))
-level_ctr(fbr::SparseData, proto::Union{typeof(laminate)}, protos...)                     = :(SparseDict($(level_ctr(fbr.lvl, protos...))))
-level_ctr(fbr::RepeatData, proto::Union{Nothing,typeof(walk),typeof(extrude)}, protos...) = :(SparseRunList($(level_ctr(fbr.lvl, protos...))))
-level_ctr(fbr::RepeatData, proto::Union{typeof(laminate)}, protos...)                     = :(SparseDict($(level_ctr(fbr.lvl, protos...))))
-level_ctr(fbr::DenseData, proto, protos...)                                               = :(Dense($(level_ctr(fbr.lvl, protos...))))
-level_ctr(fbr::ExtrudeData, proto, protos...)                                             = :(Dense($(level_ctr(fbr.lvl, protos...)), 1))
-level_ctr(fbr::RepeatData, proto::Union{Nothing,typeof(walk),typeof(extrude)})            = :(Repeat{$(fbr.fill_value),$(fbr.eltype)}())
-level_ctr(fbr::RepeatData, proto::Union{typeof(laminate)})                                = level_ctr(DenseData(ElementData(fbr.fill_value, fbr.eltype)), proto)
-level_ctr(fbr::ElementData)                                                               = :(Element{$(fbr.fill_value),$(fbr.eltype)}())
+function level_ctr(
+    fbr::SparseData, proto::Union{Nothing,typeof(walk),typeof(extrude)}, protos...
+)
+    :(SparseDict($(level_ctr(fbr.lvl, protos...))))
+end
+function level_ctr(fbr::SparseData, proto::Union{typeof(laminate)}, protos...)
+    :(SparseDict($(level_ctr(fbr.lvl, protos...))))
+end
+function level_ctr(
+    fbr::RepeatData, proto::Union{Nothing,typeof(walk),typeof(extrude)}, protos...
+)
+    :(SparseRunList($(level_ctr(fbr.lvl, protos...))))
+end
+function level_ctr(fbr::RepeatData, proto::Union{typeof(laminate)}, protos...)
+    :(SparseDict($(level_ctr(fbr.lvl, protos...))))
+end
+level_ctr(fbr::DenseData, proto, protos...) = :(Dense($(level_ctr(fbr.lvl, protos...))))
+function level_ctr(fbr::ExtrudeData, proto, protos...)
+    :(Dense($(level_ctr(fbr.lvl, protos...)), 1))
+end
+function level_ctr(fbr::RepeatData, proto::Union{Nothing,typeof(walk),typeof(extrude)})
+    :(Repeat{$(fbr.fill_value),$(fbr.eltype)}())
+end
+function level_ctr(fbr::RepeatData, proto::Union{typeof(laminate)})
+    level_ctr(DenseData(ElementData(fbr.fill_value, fbr.eltype)), proto)
+end
+level_ctr(fbr::ElementData) = :(Element{$(fbr.fill_value),$(fbr.eltype)}())

--- a/src/lower.jl
+++ b/src/lower.jl
@@ -286,8 +286,9 @@ dimension of virtual tensor `tns`. `ext` is the extent of the looplet. `proto`
 is the protocol that should be used for this index, but one doesn't need to
 unfurl all the indices at once.
 """
-unfurl(ctx, tns, ext, mode, proto) =
+function unfurl(ctx, tns, ext, mode, proto)
     throw(FinchProtocolError("$tns does not support $mode with protocol $proto"))
+end
 
 function lower_loop(ctx, root, ext)
     contain(ctx) do ctx_2
@@ -385,6 +386,7 @@ function lower_parallel_loop(ctx, root, ext::VirtualParallelDimension, device::V
                     end
                     body = redistribute(ctx_5, body, diff)
                     i = index(freshen(ctx, :i))
+                    #=TODO correct only for 1:n ranges =#
                     root_2 = loop(i, VirtualExtent(tid, tid),
                         loop(root.idx, ext.ext,
                             sieve(
@@ -393,7 +395,7 @@ function lower_parallel_loop(ctx, root, ext::VirtualParallelDimension, device::V
                                     reader(),
                                     root.idx,
                                     i,
-                                ), #=TODO correct only for 1:n ranges =#
+                                ),
                                 body,
                             ),
                         ),

--- a/src/scopes.jl
+++ b/src/scopes.jl
@@ -35,15 +35,17 @@ set_binding!(ctx::ScopeContext, var, val) = ctx.bindings[var] = val
 
 Get the binding of a variable in the context, or return a default value.
 """
-get_binding(ctx::AbstractCompiler, var, val) =
+function get_binding(ctx::AbstractCompiler, var, val)
     has_binding(ctx, var) ? get_binding(ctx, var) : val
+end
 """
     get_binding!(ctx, var, val)
 
 Get the binding of a variable in the context, or set it to a default value.
 """
-get_binding!(ctx::AbstractCompiler, var, val) =
+function get_binding!(ctx::AbstractCompiler, var, val)
     has_binding(ctx, var) ? get_binding(ctx, var) : set_binding!(ctx, var, val)
+end
 
 """
     set_declared!(ctx, var, val, op)

--- a/src/tensors/combinators/permissive.jl
+++ b/src/tensors/combinators/permissive.jl
@@ -196,12 +196,12 @@ function unfurl(ctx, tns::VirtualPermissiveArray, ext, mode, proto)
                 tns,
                 Sequence([
                     Phase(;
-                        stop = (ctx, ext_2) -> call(-, getstart(dims[end]), 1),
-                        body = (ctx, ext) -> Run(garb),
+                        stop=(ctx, ext_2) -> call(-, getstart(dims[end]), 1),
+                        body=(ctx, ext) -> Run(garb),
                     ),
                     Phase(;
-                        stop = (ctx, ext_2) -> getstop(dims[end]),
-                        body = (ctx, ext_2) -> truncate(ctx, tns_2, dims[end], ext_2),
+                        stop=(ctx, ext_2) -> getstop(dims[end]),
+                        body=(ctx, ext_2) -> truncate(ctx, tns_2, dims[end], ext_2),
                     ),
                     Phase(;
                         body=(ctx, ext_2) -> Run(garb)

--- a/src/tensors/levels/dense_rle_levels.jl
+++ b/src/tensors/levels/dense_rle_levels.jl
@@ -715,7 +715,7 @@ function unfurl(
             end,
             body=(ctx) -> AcceptRun(;
                 body=(ctx, ext) -> Thunk(;
-                    preamble = quote
+                    preamble=quote
                         $qos_3 = $qos + ($(local_i_prev) < ($(ctx(getstart(ext))) - $unit))
                         if $qos_3 > $qos_stop
                             $qos_2 = $qos_stop + 1
@@ -723,13 +723,27 @@ function unfurl(
                                 $qos_stop = max($qos_stop << 1, 1)
                             end
                             Finch.resize_if_smaller!($(lvl.right), $qos_stop)
-                            Finch.fill_range!($(lvl.right), $(ctx(lvl.shape)), $qos_2, $qos_stop)
-                            $(contain(ctx_2 -> assemble_level!(ctx_2, lvl.buf, value(qos_2, Tp), value(qos_stop, Tp)), ctx))
+                            Finch.fill_range!(
+                                $(lvl.right), $(ctx(lvl.shape)), $qos_2, $qos_stop
+                            )
+                            $(contain(
+                                ctx_2 -> assemble_level!(
+                                    ctx_2,
+                                    lvl.buf,
+                                    value(qos_2, Tp),
+                                    value(qos_stop, Tp),
+                                ),
+                                ctx,
+                            ))
                         end
                         $dirty = false
                     end,
-                    body     = (ctx) -> instantiate(ctx, VirtualHollowSubFiber(lvl.buf, value(qos_3, Tp), dirty), mode),
-                    epilogue = quote
+                    body=(ctx) -> instantiate(
+                        ctx,
+                        VirtualHollowSubFiber(lvl.buf, value(qos_3, Tp), dirty),
+                        mode,
+                    ),
+                    epilogue=quote
                         if $dirty
                             $(lvl.right)[$qos] = $(ctx(getstart(ext))) - $unit
                             $(lvl.right)[$qos_3] = $(ctx(getstop(ext)))

--- a/src/tensors/levels/sparse_bytemap_levels.jl
+++ b/src/tensors/levels/sparse_bytemap_levels.jl
@@ -437,24 +437,32 @@ function unfurl(
             end,
             body=(ctx) -> Sequence([
                 Phase(;
-                    stop = (ctx, ext) -> value(my_i_stop),
-                    body = (ctx, ext) -> Stepper(;
-                    seek=(ctx, ext) -> quote
-                        while $my_r + $(Tp(1)) < $my_r_stop && last($(lvl.srt)[$my_r]) < $(ctx(getstart(ext)))
-                            $my_r += $(Tp(1))
-                        end
-                    end,
-                    preamble=:($my_i = last($(lvl.srt)[$my_r])),
-                    stop=(ctx, ext) -> value(my_i),
-                    chunk=Spike(;
-                    body = FillLeaf(virtual_level_fill_value(lvl)),
-                    tail = Thunk(;
-                    preamble=:($my_q = ($(ctx(pos)) - $(Tp(1))) * $(ctx(lvl.shape)) + $my_i),
-                    body=(ctx) -> instantiate(ctx, VirtualSubFiber(lvl.lvl, value(my_q, lvl.Ti)), mode)
-                )
-                ),
-                    next=(ctx, ext) -> :($my_r += $(Tp(1)))
-                ),
+                    stop=(ctx, ext) -> value(my_i_stop),
+                    body=(ctx, ext) -> Stepper(;
+                        seek=(ctx, ext) -> quote
+                            while $my_r + $(Tp(1)) < $my_r_stop &&
+                                last($(lvl.srt)[$my_r]) < $(ctx(getstart(ext)))
+                                $my_r += $(Tp(1))
+                            end
+                        end,
+                        preamble=:($my_i = last($(lvl.srt)[$my_r])),
+                        stop=(ctx, ext) -> value(my_i),
+                        chunk=Spike(;
+                            body=FillLeaf(virtual_level_fill_value(lvl)),
+                            tail=Thunk(;
+                                preamble=:(
+                                    $my_q =
+                                        ($(ctx(pos)) - $(Tp(1))) * $(ctx(lvl.shape)) + $my_i
+                                ),
+                                body=(ctx) -> instantiate(
+                                    ctx,
+                                    VirtualSubFiber(lvl.lvl, value(my_q, lvl.Ti)),
+                                    mode,
+                                ),
+                            ),
+                        ),
+                        next=(ctx, ext) -> :($my_r += $(Tp(1))),
+                    ),
                 ),
                 Phase(;
                     body=(ctx, ext) -> Run(FillLeaf(virtual_level_fill_value(lvl)))
@@ -494,24 +502,32 @@ function unfurl(
             end,
             body=(ctx) -> Sequence([
                 Phase(;
-                    stop = (ctx, ext) -> value(my_i_stop),
-                    body = (ctx, ext) -> Jumper(;
-                    seek=(ctx, ext) -> quote
-                        while $my_r + $(Tp(1)) < $my_r_stop && last($(lvl.srt)[$my_r]) < $(ctx(getstart(ext)))
-                            $my_r += $(Tp(1))
-                        end
-                    end,
-                    preamble=:($my_i = last($(lvl.srt)[$my_r])),
-                    stop=(ctx, ext) -> value(my_i),
-                    chunk=Spike(;
-                    body = FillLeaf(virtual_level_fill_value(lvl)),
-                    tail = Thunk(;
-                    preamble=:($my_q = ($(ctx(pos)) - $(Tp(1))) * $(ctx(lvl.shape)) + $my_i),
-                    body=(ctx) -> instantiate(ctx, VirtualSubFiber(lvl.lvl, value(my_q, lvl.Ti)), mode)
-                )
-                ),
-                    next=(ctx, ext) -> :($my_r += $(Tp(1)))
-                ),
+                    stop=(ctx, ext) -> value(my_i_stop),
+                    body=(ctx, ext) -> Jumper(;
+                        seek=(ctx, ext) -> quote
+                            while $my_r + $(Tp(1)) < $my_r_stop &&
+                                last($(lvl.srt)[$my_r]) < $(ctx(getstart(ext)))
+                                $my_r += $(Tp(1))
+                            end
+                        end,
+                        preamble=:($my_i = last($(lvl.srt)[$my_r])),
+                        stop=(ctx, ext) -> value(my_i),
+                        chunk=Spike(;
+                            body=FillLeaf(virtual_level_fill_value(lvl)),
+                            tail=Thunk(;
+                                preamble=:(
+                                    $my_q =
+                                        ($(ctx(pos)) - $(Tp(1))) * $(ctx(lvl.shape)) + $my_i
+                                ),
+                                body=(ctx) -> instantiate(
+                                    ctx,
+                                    VirtualSubFiber(lvl.lvl, value(my_q, lvl.Ti)),
+                                    mode,
+                                ),
+                            ),
+                        ),
+                        next=(ctx, ext) -> :($my_r += $(Tp(1))),
+                    ),
                 ),
                 Phase(;
                     body=(ctx, ext) -> Run(FillLeaf(virtual_level_fill_value(lvl)))
@@ -576,12 +592,16 @@ function unfurl(
         arr=fbr,
         body=Lookup(;
             body=(ctx, idx) -> Thunk(;
-                preamble = quote
+                preamble=quote
                     $my_q = ($(ctx(pos)) - $(Tp(1))) * $(ctx(lvl.shape)) + $(ctx(idx))
                     $dirty = false
                 end,
-                body     = (ctx) -> instantiate(ctx, VirtualHollowSubFiber(lvl.lvl, value(my_q, lvl.Ti), dirty), mode),
-                epilogue = quote
+                body=(ctx) -> instantiate(
+                    ctx,
+                    VirtualHollowSubFiber(lvl.lvl, value(my_q, lvl.Ti), dirty),
+                    mode,
+                ),
+                epilogue=quote
                     if $dirty
                         $(fbr.dirty) = true
                         if !$(lvl.tbl)[$my_q]

--- a/src/tensors/levels/sparse_dict_levels.jl
+++ b/src/tensors/levels/sparse_dict_levels.jl
@@ -454,25 +454,34 @@ function unfurl(
         end,
         body=(ctx) -> Sequence([
             Phase(;
-                stop = (ctx, ext) -> value(my_i1),
-                body = (ctx, ext) -> Stepper(;
-                seek=(ctx, ext) -> quote
-                    if $(lvl.idx)[$my_q] < $(ctx(getstart(ext)))
-                        $my_q = Finch.scansearch($(lvl.idx), $(ctx(getstart(ext))), $my_q, $my_q_stop - 1)
+                stop=(ctx, ext) -> value(my_i1),
+                body=(ctx, ext) -> Stepper(;
+                    seek=(ctx, ext) -> quote
+                        if $(lvl.idx)[$my_q] < $(ctx(getstart(ext)))
+                            $my_q = Finch.scansearch(
+                                $(lvl.idx),
+                                $(ctx(getstart(ext))),
+                                $my_q,
+                                $my_q_stop - 1,
+                            )
+                            $my_i = $(lvl.idx)[$my_q]
+                        end
+                    end,
+                    preamble=quote
                         $my_i = $(lvl.idx)[$my_q]
-                    end
-                end,
-                preamble=quote
-                    $my_i = $(lvl.idx)[$my_q]
-                    $my_v = $(lvl.val)[$my_q]
-                end,
-                stop=(ctx, ext) -> value(my_i),
-                chunk=Spike(;
-                body = FillLeaf(virtual_level_fill_value(lvl)),
-                tail = Simplify(instantiate(ctx, VirtualSubFiber(lvl.lvl, value(my_v, Ti)), mode))
-            ),
-                next=(ctx, ext) -> :($my_q += $(Tp(1)))
-            ),
+                        $my_v = $(lvl.val)[$my_q]
+                    end,
+                    stop=(ctx, ext) -> value(my_i),
+                    chunk=Spike(;
+                        body=FillLeaf(virtual_level_fill_value(lvl)),
+                        tail=Simplify(
+                            instantiate(
+                                ctx, VirtualSubFiber(lvl.lvl, value(my_v, Ti)), mode
+                            ),
+                        ),
+                    ),
+                    next=(ctx, ext) -> :($my_q += $(Tp(1))),
+                ),
             ),
             Phase(;
                 body=(ctx, ext) -> Run(FillLeaf(virtual_level_fill_value(lvl)))
@@ -534,7 +543,7 @@ function unfurl(
     Thunk(;
         body=(ctx) -> Lookup(;
             body=(ctx, idx) -> Thunk(;
-                preamble = quote
+                preamble=quote
                     $qos = get($(lvl.tbl), ($(ctx(pos)), $(ctx(idx))), 0)
                     if $qos == 0
                         #If the qos is not in the table, we need to add it.
@@ -546,7 +555,15 @@ function unfurl(
                             $qos = length($(lvl.tbl)) + 1
                             if $qos > $qos_stop
                                 $qos_stop = max($qos_stop << 1, 1)
-                                $(contain(ctx_2 -> assemble_level!(ctx_2, lvl.lvl, value(qos, Tp), value(qos_stop, Tp)), ctx))
+                                $(contain(
+                                    ctx_2 -> assemble_level!(
+                                        ctx_2,
+                                        lvl.lvl,
+                                        value(qos, Tp),
+                                        value(qos_stop, Tp),
+                                    ),
+                                    ctx,
+                                ))
                                 Finch.resize_if_smaller!($(lvl.val), $qos_stop)
                                 Finch.fill_range!($(lvl.val), 0, $qos, $qos_stop)
                             end
@@ -555,8 +572,12 @@ function unfurl(
                     end
                     $dirty = false
                 end,
-                body     = (ctx) -> instantiate(ctx, VirtualHollowSubFiber(lvl.lvl, value(qos, Tp), dirty), mode),
-                epilogue = quote
+                body=(ctx) -> instantiate(
+                    ctx,
+                    VirtualHollowSubFiber(lvl.lvl, value(qos, Tp), dirty),
+                    mode,
+                ),
+                epilogue=quote
                     if $dirty
                         $(lvl.val)[$qos] = $qos
                         $(fbr.dirty) = true

--- a/src/tensors/levels/sparse_interval_levels.jl
+++ b/src/tensors/levels/sparse_interval_levels.jl
@@ -360,12 +360,14 @@ function unfurl(
                 body=(ctx, ext) -> Run(FillLeaf(virtual_level_fill_value(lvl))),
             ),
             Phase(;
-                stop = (ctx, ext) -> value(my_i_stop, lvl.Ti),
-                body = (ctx, ext) -> Run(Simplify(instantiate(ctx, VirtualSubFiber(lvl.lvl, pos), mode))),
+                stop=(ctx, ext) -> value(my_i_stop, lvl.Ti),
+                body=(ctx, ext) -> Run(
+                    Simplify(instantiate(ctx, VirtualSubFiber(lvl.lvl, pos), mode))
+                ),
             ),
             Phase(;
-                stop = (ctx, ext) -> lvl.shape,
-                body = (ctx, ext) -> Run(FillLeaf(virtual_level_fill_value(lvl))),
+                stop=(ctx, ext) -> lvl.shape,
+                body=(ctx, ext) -> Run(FillLeaf(virtual_level_fill_value(lvl))),
             ),
         ]),
     )
@@ -399,22 +401,30 @@ function unfurl(
     Thunk(;
         body=(ctx) -> AcceptRun(;
             body=(ctx, ext) -> Thunk(;
-                preamble = quote
+                preamble=quote
                     $dirty = false
                 end,
-                body     = (ctx) -> instantiate(ctx, VirtualHollowSubFiber(lvl.lvl, pos, dirty), mode),
-                epilogue = quote
+                body=(ctx) -> instantiate(
+                    ctx, VirtualHollowSubFiber(lvl.lvl, pos, dirty), mode
+                ),
+                epilogue=quote
                     if $dirty
                         $(fbr.dirty) = true
                         $(lvl.left)[$(ctx(pos))] < $(lvl.right)[$(ctx(pos))] &&
-                        throw(FinchProtocolError("SparseIntervalLevels can only be updated once"))
+                            throw(
+                                FinchProtocolError(
+                                    "SparseIntervalLevels can only be updated once"
+                                ),
+                            )
                         $(lvl.left)[$(ctx(pos))] = $(ctx(getstart(ext)))
                         $(lvl.right)[$(ctx(pos))] = $(ctx(getstop(ext)))
-                        $(if issafe(get_mode_flag(ctx))
-                            quote
-                                $(lvl.prev_pos) = $(ctx(pos))
+                        $(
+                            if issafe(get_mode_flag(ctx))
+                                quote
+                                    $(lvl.prev_pos) = $(ctx(pos))
+                                end
                             end
-                        end)
+                        )
                     end
                 end,
             ),

--- a/src/tensors/levels/sparse_point_levels.jl
+++ b/src/tensors/levels/sparse_point_levels.jl
@@ -306,16 +306,16 @@ function unfurl(
                 body=(ctx, ext) -> truncate(
                     ctx,
                     Spike(;
-                        body = FillLeaf(virtual_level_fill_value(lvl)),
-                        tail = instantiate(ctx, VirtualSubFiber(lvl.lvl, pos), mode),
+                        body=FillLeaf(virtual_level_fill_value(lvl)),
+                        tail=instantiate(ctx, VirtualSubFiber(lvl.lvl, pos), mode),
                     ),
                     similar_extent(ext, getstart(ext), value(my_i)),
                     ext,
                 ),
             ),
             Phase(;
-                stop = (ctx, ext) -> lvl.shape,
-                body = (ctx, ext) -> Run(FillLeaf(virtual_level_fill_value(lvl))),
+                stop=(ctx, ext) -> lvl.shape,
+                body=(ctx, ext) -> Run(FillLeaf(virtual_level_fill_value(lvl))),
             ),
         ]),
     )
@@ -347,15 +347,17 @@ function unfurl(
 
     Lookup(;
         body=(ctx, idx) -> Thunk(;
-            preamble = quote
+            preamble=quote
                 $dirty = false
             end,
-            body     = (ctx) -> instantiate(ctx, VirtualHollowSubFiber(lvl.lvl, pos, dirty), mode),
-            epilogue = quote
+            body=(ctx) ->
+                instantiate(ctx, VirtualHollowSubFiber(lvl.lvl, pos, dirty), mode),
+            epilogue=quote
                 if $dirty
                     $(fbr.dirty) = true
                     if $(issafe(get_mode_flag(ctx)))
-                        @assert $(lvl.idx)[$(ctx(pos))] == 0 || $(lvl.idx)[$(ctx(pos))] == $(ctx(idx))
+                        @assert $(lvl.idx)[$(ctx(pos))] == 0 ||
+                            $(lvl.idx)[$(ctx(pos))] == $(ctx(idx))
                     end
                     $(lvl.idx)[$(ctx(pos))] = $(ctx(idx))
                 end

--- a/src/tensors/levels/sparse_rle_levels.jl
+++ b/src/tensors/levels/sparse_rle_levels.jl
@@ -615,35 +615,48 @@ function unfurl(
         end,
         body=(ctx) -> Sequence([
             Phase(;
-                stop = (ctx, ext) -> value(my_i_end),
-                body = (ctx, ext) -> Stepper(;
-                seek=(ctx, ext) -> quote
-                    if $(lvl.right)[$my_q] < $(ctx(getstart(ext)))
-                        $my_q = Finch.scansearch($(lvl.right), $(ctx(getstart(ext))), $my_q, $my_q_stop - 1)
-                    end
-                end,
-                preamble=quote
-                    $my_i_start = $(lvl.left)[$my_q]
-                    $my_i_stop = $(lvl.right)[$my_q]
-                end,
-                stop=(ctx, ext) -> value(my_i_stop),
-                body=(ctx, ext) -> Thunk(;
-                body=(ctx) -> Sequence([
-                Phase(;
-                stop = (ctx, ext) -> call(-, value(my_i_start), getunit(ext)),
-                body = (ctx, ext) -> Run(FillLeaf(virtual_level_fill_value(lvl)))
-            ),
-                Phase(;
-                body=(ctx, ext) -> Run(;
-                body=Simplify(instantiate(ctx, VirtualSubFiber(lvl.lvl, value(my_q)), mode))
-            )
-            )
-            ]),
-                epilogue=quote
-                    $my_q += ($(ctx(getstop(ext))) == $my_i_stop)
-                end
-            )
-            ),
+                stop=(ctx, ext) -> value(my_i_end),
+                body=(ctx, ext) -> Stepper(;
+                    seek=(ctx, ext) -> quote
+                        if $(lvl.right)[$my_q] < $(ctx(getstart(ext)))
+                            $my_q = Finch.scansearch(
+                                $(lvl.right),
+                                $(ctx(getstart(ext))),
+                                $my_q,
+                                $my_q_stop - 1,
+                            )
+                        end
+                    end,
+                    preamble=quote
+                        $my_i_start = $(lvl.left)[$my_q]
+                        $my_i_stop = $(lvl.right)[$my_q]
+                    end,
+                    stop=(ctx, ext) -> value(my_i_stop),
+                    body=(ctx, ext) -> Thunk(;
+                        body=(ctx) -> Sequence([
+                            Phase(;
+                                stop=(ctx, ext) -> call(-, value(my_i_start), getunit(ext)),
+                                body=(ctx, ext) -> Run(
+                                    FillLeaf(virtual_level_fill_value(lvl))
+                                ),
+                            ),
+                            Phase(;
+                                body=(ctx, ext) -> Run(;
+                                    body=Simplify(
+                                        instantiate(
+                                            ctx,
+                                            VirtualSubFiber(lvl.lvl, value(my_q)),
+                                            mode,
+                                        ),
+                                    ),
+                                ),
+                            ),
+                        ]),
+                        epilogue=quote
+                            $my_q += ($(ctx(getstop(ext))) == $my_i_stop)
+                        end,
+                    ),
+                ),
             ),
             Phase(;
                 body=(ctx, ext) -> Run(FillLeaf(virtual_level_fill_value(lvl)))
@@ -697,27 +710,41 @@ function unfurl(
         end,
         body=(ctx) -> AcceptRun(;
             body=(ctx, ext) -> Thunk(;
-                preamble = quote
+                preamble=quote
                     if $qos > $qos_stop
                         $qos_stop = max($qos_stop << 1, 1)
                         Finch.resize_if_smaller!($(lvl.left), $qos_stop)
                         Finch.resize_if_smaller!($(lvl.right), $qos_stop)
-                        $(contain(ctx_2 -> assemble_level!(ctx_2, lvl.buf, value(qos, Tp), value(qos_stop, Tp)), ctx))
+                        $(contain(
+                            ctx_2 -> assemble_level!(
+                                ctx_2,
+                                lvl.buf,
+                                value(qos, Tp),
+                                value(qos_stop, Tp),
+                            ),
+                            ctx,
+                        ))
                     end
                     $dirty = false
                 end,
-                body     = (ctx) -> instantiate(ctx, VirtualHollowSubFiber(lvl.buf, value(qos, Tp), dirty), mode),
-                epilogue = quote
+                body=(ctx) -> instantiate(
+                    ctx,
+                    VirtualHollowSubFiber(lvl.buf, value(qos, Tp), dirty),
+                    mode,
+                ),
+                epilogue=quote
                     if $dirty
                         $(fbr.dirty) = true
                         $(lvl.left)[$qos] = $(ctx(getstart(ext)))
                         $(lvl.right)[$qos] = $(ctx(getstop(ext)))
                         $(qos) += $(Tp(1))
-                        $(if issafe(get_mode_flag(ctx))
-                            quote
-                                $(lvl.prev_pos) = $(ctx(pos))
+                        $(
+                            if issafe(get_mode_flag(ctx))
+                                quote
+                                    $(lvl.prev_pos) = $(ctx(pos))
+                                end
                             end
-                        end)
+                        )
                     end
                 end,
             ),

--- a/src/tensors/levels/sparse_vbl_levels.jl
+++ b/src/tensors/levels/sparse_vbl_levels.jl
@@ -424,40 +424,51 @@ function unfurl(
         end,
         body=(ctx) -> Sequence([
             Phase(;
-                stop = (ctx, ext) -> value(my_i1),
-                body = (ctx, ext) -> Stepper(;
-                seek=(ctx, ext) -> quote
-                    if $(lvl.idx)[$my_r] < $(ctx(getstart(ext)))
-                        $my_r = Finch.scansearch($(lvl.idx), $(ctx(getstart(ext))), $my_r, $my_r_stop - 1)
-                    end
-                end,
-                preamble=quote
-                    $my_i = $(lvl.idx)[$my_r]
-                    $my_q_stop = $(lvl.ofs)[$my_r + $(Tp(1))]
-                    $my_i_start = $my_i - ($my_q_stop - $(lvl.ofs)[$my_r])
-                    $my_q_ofs = $my_q_stop - $my_i - $(Tp(1))
-                end,
-                stop=(ctx, ext) -> value(my_i),
-                body=(ctx, ext) -> Thunk(;
-                body=(ctx) -> Sequence([
-                Phase(;
-                stop = (ctx, ext) -> value(my_i_start),
-                body = (ctx, ext) -> Run(FillLeaf(virtual_level_fill_value(lvl)))
-            ),
-                Phase(;
-                body=(ctx, ext) -> Lookup(;
-                body=(ctx, i) -> Thunk(;
-                preamble=:($my_q = $my_q_ofs + $(ctx(i))),
-                body=(ctx) -> instantiate(ctx, VirtualSubFiber(lvl.lvl, value(my_q, Tp)), mode)
-            )
-            )
-            )
-            ]),
-                epilogue=quote
-                    $my_r += ($(ctx(getstop(ext))) == $my_i)
-                end
-            )
-            ),
+                stop=(ctx, ext) -> value(my_i1),
+                body=(ctx, ext) -> Stepper(;
+                    seek=(ctx, ext) -> quote
+                        if $(lvl.idx)[$my_r] < $(ctx(getstart(ext)))
+                            $my_r = Finch.scansearch(
+                                $(lvl.idx),
+                                $(ctx(getstart(ext))),
+                                $my_r,
+                                $my_r_stop - 1,
+                            )
+                        end
+                    end,
+                    preamble=quote
+                        $my_i = $(lvl.idx)[$my_r]
+                        $my_q_stop = $(lvl.ofs)[$my_r + $(Tp(1))]
+                        $my_i_start = $my_i - ($my_q_stop - $(lvl.ofs)[$my_r])
+                        $my_q_ofs = $my_q_stop - $my_i - $(Tp(1))
+                    end,
+                    stop=(ctx, ext) -> value(my_i),
+                    body=(ctx, ext) -> Thunk(;
+                        body=(ctx) -> Sequence([
+                            Phase(;
+                                stop=(ctx, ext) -> value(my_i_start),
+                                body=(ctx, ext) -> Run(
+                                    FillLeaf(virtual_level_fill_value(lvl))
+                                ),
+                            ),
+                            Phase(;
+                                body=(ctx, ext) -> Lookup(;
+                                    body=(ctx, i) -> Thunk(;
+                                        preamble=:($my_q = $my_q_ofs + $(ctx(i))),
+                                        body=(ctx) -> instantiate(
+                                            ctx,
+                                            VirtualSubFiber(lvl.lvl, value(my_q, Tp)),
+                                            mode,
+                                        ),
+                                    ),
+                                ),
+                            ),
+                        ]),
+                        epilogue=quote
+                            $my_r += ($(ctx(getstop(ext))) == $my_i)
+                        end,
+                    ),
+                ),
             ),
             Phase(;
                 body=(ctx, ext) -> Run(FillLeaf(virtual_level_fill_value(lvl)))
@@ -497,36 +508,46 @@ function unfurl(
         end,
         body=(ctx) -> Sequence([
             Phase(;
-                stop = (ctx, ext) -> value(my_i1),
-                body = (ctx, ext) -> Jumper(;
-                seek=(ctx, ext) -> quote
-                    if $(lvl.idx)[$my_r] < $(ctx(getstart(ext)))
-                        $my_r = Finch.scansearch($(lvl.idx), $(ctx(getstart(ext))), $my_r, $my_r_stop - 1)
-                    end
-                end,
-                preamble=quote
-                    $my_i = $(lvl.idx)[$my_r]
-                    $my_q_stop = $(lvl.ofs)[$my_r + $(Tp(1))]
-                    $my_i_start = $my_i - ($my_q_stop - $(lvl.ofs)[$my_r])
-                    $my_q_ofs = $my_q_stop - $my_i - $(Tp(1))
-                end,
-                stop=(ctx, ext) -> value(my_i),
-                chunk=Sequence([
-                Phase(;
-                stop = (ctx, ext) -> value(my_i_start),
-                body = (ctx, ext) -> Run(FillLeaf(virtual_level_fill_value(lvl)))
-            ),
-                Phase(;
-                body=(ctx, ext) -> Lookup(;
-                body=(ctx, i) -> Thunk(;
-                preamble=:($my_q = $my_q_ofs + $(ctx(i))),
-                body=(ctx) -> instantiate(ctx, VirtualSubFiber(lvl.lvl, value(my_q, Tp)), mode)
-            )
-            )
-            )
-            ]),
-                next=(ctx, ext) -> :($my_r += $(Tp(1)))
-            ),
+                stop=(ctx, ext) -> value(my_i1),
+                body=(ctx, ext) -> Jumper(;
+                    seek=(ctx, ext) -> quote
+                        if $(lvl.idx)[$my_r] < $(ctx(getstart(ext)))
+                            $my_r = Finch.scansearch(
+                                $(lvl.idx),
+                                $(ctx(getstart(ext))),
+                                $my_r,
+                                $my_r_stop - 1,
+                            )
+                        end
+                    end,
+                    preamble=quote
+                        $my_i = $(lvl.idx)[$my_r]
+                        $my_q_stop = $(lvl.ofs)[$my_r + $(Tp(1))]
+                        $my_i_start = $my_i - ($my_q_stop - $(lvl.ofs)[$my_r])
+                        $my_q_ofs = $my_q_stop - $my_i - $(Tp(1))
+                    end,
+                    stop=(ctx, ext) -> value(my_i),
+                    chunk=Sequence([
+                        Phase(;
+                            stop=(ctx, ext) -> value(my_i_start),
+                            body=(ctx, ext) ->
+                                Run(FillLeaf(virtual_level_fill_value(lvl))),
+                        ),
+                        Phase(;
+                            body=(ctx, ext) -> Lookup(;
+                                body=(ctx, i) -> Thunk(;
+                                    preamble=:($my_q = $my_q_ofs + $(ctx(i))),
+                                    body=(ctx) -> instantiate(
+                                        ctx,
+                                        VirtualSubFiber(lvl.lvl, value(my_q, Tp)),
+                                        mode,
+                                    ),
+                                ),
+                            ),
+                        ),
+                    ]),
+                    next=(ctx, ext) -> :($my_r += $(Tp(1))),
+                ),
             ),
             Phase(;
                 body=(ctx, ext) -> Run(FillLeaf(virtual_level_fill_value(lvl)))
@@ -569,50 +590,70 @@ function unfurl(
     dirty = freshen(ctx, tag, :dirty)
 
     Thunk(;
-        preamble = quote
+        preamble=quote
             $ros = $ros_fill
             $qos = $qos_fill + 1
             $my_i_prev = $(Ti(-1))
-            $(if issafe(get_mode_flag(ctx))
-                quote
-                    $(lvl.prev_pos) < $(ctx(pos)) || throw(FinchProtocolError("SparseBlockListLevels cannot be updated multiple times"))
-                end
-            end)
-        end,
-        body     = (ctx) -> Lookup(;
-        body=(ctx, idx) -> Thunk(;
-        preamble = quote
-            if $qos > $qos_stop
-                $qos_stop = max($qos_stop << 1, 1)
-                $(contain(ctx_2 -> assemble_level!(ctx_2, lvl.lvl, value(qos, Tp), value(qos_stop, Tp)), ctx))
-            end
-            $dirty = false
-        end,
-        body     = (ctx) -> instantiate(ctx, VirtualHollowSubFiber(lvl.lvl, value(qos, Tp), dirty), mode),
-        epilogue = quote
-            if $dirty
-                $(fbr.dirty) = true
-                if $(ctx(idx)) > $my_i_prev + $(Ti(1))
-                    $ros += $(Tp(1))
-                    if $ros > $ros_stop
-                        $ros_stop = max($ros_stop << 1, 1)
-                        Finch.resize_if_smaller!($(lvl.idx), $ros_stop)
-                        Finch.resize_if_smaller!($(lvl.ofs), $ros_stop + 1)
-                    end
-                end
-                $(lvl.idx)[$ros] = $my_i_prev = $(ctx(idx))
-                $(qos) += $(Tp(1))
-                $(lvl.ofs)[$ros + 1] = $qos
-                $(if issafe(get_mode_flag(ctx))
+            $(
+                if issafe(get_mode_flag(ctx))
                     quote
-                        $(lvl.prev_pos) = $(ctx(pos))
+                        $(lvl.prev_pos) < $(ctx(pos)) || throw(
+                            FinchProtocolError(
+                                "SparseBlockListLevels cannot be updated multiple times"
+                            ),
+                        )
                     end
-                end)
-            end
-        end
-    )
-    ),
-        epilogue = quote
+                end
+            )
+        end,
+        body=(ctx) -> Lookup(;
+            body=(ctx, idx) -> Thunk(;
+                preamble=quote
+                    if $qos > $qos_stop
+                        $qos_stop = max($qos_stop << 1, 1)
+                        $(contain(
+                            ctx_2 -> assemble_level!(
+                                ctx_2,
+                                lvl.lvl,
+                                value(qos, Tp),
+                                value(qos_stop, Tp),
+                            ),
+                            ctx,
+                        ))
+                    end
+                    $dirty = false
+                end,
+                body=(ctx) -> instantiate(
+                    ctx,
+                    VirtualHollowSubFiber(lvl.lvl, value(qos, Tp), dirty),
+                    mode,
+                ),
+                epilogue=quote
+                    if $dirty
+                        $(fbr.dirty) = true
+                        if $(ctx(idx)) > $my_i_prev + $(Ti(1))
+                            $ros += $(Tp(1))
+                            if $ros > $ros_stop
+                                $ros_stop = max($ros_stop << 1, 1)
+                                Finch.resize_if_smaller!($(lvl.idx), $ros_stop)
+                                Finch.resize_if_smaller!($(lvl.ofs), $ros_stop + 1)
+                            end
+                        end
+                        $(lvl.idx)[$ros] = $my_i_prev = $(ctx(idx))
+                        $(qos) += $(Tp(1))
+                        $(lvl.ofs)[$ros + 1] = $qos
+                        $(
+                            if issafe(get_mode_flag(ctx))
+                                quote
+                                    $(lvl.prev_pos) = $(ctx(pos))
+                                end
+                            end
+                        )
+                    end
+                end,
+            ),
+        ),
+        epilogue=quote
             $(lvl.ptr)[$(ctx(pos)) + 1] = $ros - $ros_fill
             $ros_fill = $ros
             $qos_fill = $qos - 1

--- a/src/tensors/masks.jl
+++ b/src/tensors/masks.jl
@@ -38,12 +38,12 @@ function unfurl(ctx, arr::VirtualDiagMaskColumn, ext, mode, proto::typeof(defaul
     j = arr.j
     Sequence([
         Phase(;
-            stop = (ctx, ext) -> value(:($(ctx(j)) - 1)),
-            body = (ctx, ext) -> Run(; body=FillLeaf(false)),
+            stop=(ctx, ext) -> value(:($(ctx(j)) - 1)),
+            body=(ctx, ext) -> Run(; body=FillLeaf(false)),
         ),
         Phase(;
-            stop = (ctx, ext) -> j,
-            body = (ctx, ext) -> Run(; body=FillLeaf(true)),
+            stop=(ctx, ext) -> j,
+            body=(ctx, ext) -> Run(; body=FillLeaf(true)),
         ),
         Phase(; body=(ctx, ext) -> Run(; body=FillLeaf(false))),
     ])
@@ -89,8 +89,8 @@ function unfurl(ctx, arr::VirtualUpTriMaskColumn, ext, mode, proto::typeof(defau
     j = arr.j
     Sequence([
         Phase(;
-            stop = (ctx, ext) -> value(:($(ctx(j)))),
-            body = (ctx, ext) -> Run(; body=FillLeaf(true)),
+            stop=(ctx, ext) -> value(:($(ctx(j)))),
+            body=(ctx, ext) -> Run(; body=FillLeaf(true)),
         ),
         Phase(;
             body=(ctx, ext) -> Run(; body=FillLeaf(false))
@@ -138,8 +138,8 @@ function unfurl(ctx, arr::VirtualLoTriMaskColumn, ext, mode, proto::typeof(defau
     j = arr.j
     Sequence([
         Phase(;
-            stop = (ctx, ext) -> value(:($(ctx(j)) - 1)),
-            body = (ctx, ext) -> Run(; body=FillLeaf(false)),
+            stop=(ctx, ext) -> value(:($(ctx(j)) - 1)),
+            body=(ctx, ext) -> Run(; body=FillLeaf(false)),
         ),
         Phase(;
             body=(ctx, ext) -> Run(; body=FillLeaf(true))
@@ -199,12 +199,12 @@ end
 function unfurl(ctx, arr::VirtualBandMaskColumn, ext, mode, proto::typeof(defaultread))
     Sequence([
         Phase(;
-            stop = (ctx, ext) -> value(:($(ctx(j)) - 1)),
-            body = (ctx, ext) -> Run(; body=FillLeaf(false)),
+            stop=(ctx, ext) -> value(:($(ctx(j)) - 1)),
+            body=(ctx, ext) -> Run(; body=FillLeaf(false)),
         ),
         Phase(;
-            stop = (ctx, ext) -> k,
-            body = (ctx, ext) -> Run(; body=FillLeaf(true)),
+            stop=(ctx, ext) -> k,
+            body=(ctx, ext) -> Run(; body=FillLeaf(true)),
         ),
         Phase(;
             body=(ctx, ext) -> Run(; body=FillLeaf(false))
@@ -299,12 +299,12 @@ function unfurl(ctx, arr::VirtualSplitMaskColumn, ext_2, mode, proto::typeof(def
     P = arr.arr.P
     Sequence([
         Phase(;
-            stop = (ctx, ext) -> call(fld, call(*, arr.arr.stop, call(-, j, 1)), P),
-            body = (ctx, ext) -> Run(; body=FillLeaf(false)),
+            stop=(ctx, ext) -> call(fld, call(*, arr.arr.stop, call(-, j, 1)), P),
+            body=(ctx, ext) -> Run(; body=FillLeaf(false)),
         ),
         Phase(;
-            stop = (ctx, ext) -> call(fld, call(*, arr.arr.stop, j), P),
-            body = (ctx, ext) -> Run(; body=FillLeaf(true)),
+            stop=(ctx, ext) -> call(fld, call(*, arr.arr.stop, j), P),
+            body=(ctx, ext) -> Run(; body=FillLeaf(true)),
         ),
         Phase(; body=(ctx, ext) -> Run(; body=FillLeaf(false))),
     ])
@@ -397,10 +397,10 @@ function unfurl(ctx, arr::VirtualChunkMask, ext, mode, proto::typeof(defaultread
         arr=arr,
         body=Sequence([
             Phase(;
-                stop = (ctx, ext) -> call(cld, arr.stop, arr.b),
-                body = (ctx, ext) -> Lookup(;
-                body=(ctx, j) -> VirtualChunkMaskColumn(arr, j)
-            ),
+                stop=(ctx, ext) -> call(cld, arr.stop, arr.b),
+                body=(ctx, ext) -> Lookup(;
+                    body=(ctx, j) -> VirtualChunkMaskColumn(arr, j)
+                ),
             ),
             Phase(;
                 body=(ctx, ext) -> Run(;
@@ -415,12 +415,12 @@ function unfurl(ctx, arr::VirtualChunkMaskColumn, ext, mode, proto::typeof(defau
     j = arr.j
     Sequence([
         Phase(;
-            stop = (ctx, ext) -> call(*, arr.arr.b, call(-, j, 1)),
-            body = (ctx, ext) -> Run(; body=FillLeaf(false)),
+            stop=(ctx, ext) -> call(*, arr.arr.b, call(-, j, 1)),
+            body=(ctx, ext) -> Run(; body=FillLeaf(false)),
         ),
         Phase(;
-            stop = (ctx, ext) -> call(*, arr.arr.b, j),
-            body = (ctx, ext) -> Run(; body=FillLeaf(true)),
+            stop=(ctx, ext) -> call(*, arr.arr.b, j),
+            body=(ctx, ext) -> Run(; body=FillLeaf(true)),
         ),
         Phase(; body=(ctx, ext) -> Run(; body=FillLeaf(false))),
     ])
@@ -431,8 +431,8 @@ function unfurl(
 )
     Sequence([
         Phase(;
-            stop = (ctx, ext) -> call(*, call(fld, arr.arr.stop, arr.arr.b), arr.arr.b),
-            body = (ctx, ext) -> Run(; body=FillLeaf(false)),
+            stop=(ctx, ext) -> call(*, call(fld, arr.arr.stop, arr.arr.b), arr.arr.b),
+            body=(ctx, ext) -> Run(; body=FillLeaf(false)),
         ),
         Phase(;
             body=(ctx, ext) -> Run(; body=FillLeaf(true))

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -31,3 +31,6 @@ TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 TensorMarket = "8b7d4fe7-0b45-4d0d-9dd8-5cc9b23b4b77"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+
+[compat]
+JuliaFormatter = "1.0, 2"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -33,4 +33,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
-JuliaFormatter = "1.0, 2"
+JuliaFormatter = "1.0.62"

--- a/test/suites/interface_tests.jl
+++ b/test/suites/interface_tests.jl
@@ -928,6 +928,13 @@ end
                     @test size(v) == (3, 2)
                     @test expanddims(v, 2) == u
                 end
+
+                #https://github.com/finch-tensor/Finch.jl/issues/726
+                let
+                    A = Tensor(Dense(SparseList(Element(0))), [1 2 3; 4 5 6; 7 8 9])
+                    B = compute(expanddims(sum(lazy(A)), 1))
+                    @test size(B) == (1,)
+                end
             end
         end
     end


### PR DESCRIPTION
fixes #726 by refusing to move extruding reorders into aggregates.

A more complete fix might also include a pass to calculate which dimensions are extruded. This PR includes such a pass, but does not use it or test it. We do leave a note about the semantics of mapjoin, which is that dimensions added through reorders are known as "extruded" dimensions, and these dimensions have length 1, but may be mapjoined with regular dimensions through broadcasting.