### PR TITLE
Scheduler regression change

### DIFF
--- a/src/scheduler/optimize.jl
+++ b/src/scheduler/optimize.jl
@@ -172,14 +172,15 @@ function push_fields(root)
                         idxs...,
                     )),
                 (@rule reorder(aggregate(~op, ~init, ~arg, ~idxs...), ~idxs_2...) =>
-                    if !issubsequence(intersect(getfields(arg), idxs_2), idxs_2)
-                        reorder(
+                        begin
+                            #TODO it should be correct to write this, but subsequent phases interpret singleton dimensions as canonical ones when we do this.
+                            #aggregate(op, init, reorder(arg, idxs_2..., idxs...), idxs...)
                             aggregate(
                                 op,
                                 init,
-                                reorder(arg, withsubsequence(idxs_2, getfields(arg))...),
+                                reorder(arg, intersect(getfields(arg), idxs_2)..., idxs...),
                                 idxs...,
-                            ), idxs_2...)
+                            )
                     end),
             ]),
         ),


### PR DESCRIPTION
Hi @willow-ahrens,

I'm going back with the regression that I reported earlier: The regression is indeed present, although in the issue I showed incorrect reproduction example.

I did `git bisect` on the correct Counting Triangle example and the commit that introduced is https://github.com/finch-tensor/Finch.jl/commit/8b74ba9fb5bcd36c7ac195a2b4d79ce1d60d0a7a.

Given the code below, the last `@time compute(plan, ctx=Finch.default_scheduler())` takes 8sec (the regression), but when reversing the aforementioned commit it's again 0.17sec.

```julia
using Finch;

size_n = 5000;
density = 0.01;

a_raw = fsprand(size_n, size_n, density);
b_raw = Tensor(CSCFormat(), a_raw);

b = lazy(swizzle(b_raw, 1, 2));
b_t = permutedims(b_raw, (2, 1));

plan = sum(
    broadcast(*, sum(broadcast(*, b[:, nothing, :], b_t[nothing, :, :]), dims=(3,)), b)
);

compute(plan, ctx=Finch.default_scheduler());
@time compute(plan, ctx=Finch.default_scheduler())
```

I don't think that the change here is sufficient - it's only pinning down where regression appeared. 