### PR TITLE
fix: 4d sparse statistics crashed on an undefined accumulator (closes #812)

### DIFF
--- a/src/Galley/TensorStats/tensor-stats.jl
+++ b/src/Galley/TensorStats/tensor-stats.jl
@@ -707,7 +707,7 @@ function _4d_structure_to_dcs(indices::Vector{Int}, s::Tensor)
     n_l, n_k, n_j, n_i = size(s)
     d_ijkl = Scalar(0)
     @finch begin
-        d_ijk .= 0
+        d_ijkl .= 0
         for i in _
             for j in _
                 for k in _

--- a/test/suites/galley_tests.jl
+++ b/test/suites/galley_tests.jl
@@ -410,6 +410,14 @@
     @testset "NaiveStats" begin end
 
     @testset verbose = true "DCStats" begin
+        @testset "4d sparse structure" begin
+            A = Tensor(
+                Dense(Sparse(Sparse(Sparse(Element(0.0))))), fsprand(5, 5, 5, 5, 0.3)
+            )
+            stats = DCStats(A, [:i, :j, :k, :l])
+            @test estimate_nnz(stats) >= 0
+        end
+
         @testset "Single Tensor Card" begin
             i = IndexExpr("i")
             j = IndexExpr("j")


### PR DESCRIPTION
The first `@finch` block of `_4d_structure_to_dcs` initializes `d_ijk` while the declared accumulator is `d_ijkl`:

```julia
d_ijkl = Scalar(0)
@finch begin
    d_ijk .= 0          # <- the 3d accumulator's name; UndefVarError on first touch
```

so `DCStats` could never be built for any rank-4 sparse input. Closes #812.

Reproduction, restated here so the PR stands alone:

```julia
using Finch
g = Finch.galley_scheduler()
A = fsprand(20, 20, 20, 20, 0.05)
B = Tensor(Dense(Dense(Element(0.0))), rand(20, 4))
compute(tensordot(lazy(A), lazy(B), ((4,), (1,))); ctx=g)
# before this patch: ERROR: UndefVarError: `d_ijk` not defined in local scope
```

The same error fires for nested `SparseList` formats too — this function is the statistics entry for every rank-4 sparse input, whatever the level types.

One-line fix, plus a regression test in the DCStats suite constructing statistics for a rank-4 sparse tensor.

Validated on this branch:

- the reproduction above plans and computes, with values matching a dense reference;
- a `Dense(SparseList(SparseList(SparseList(Element))))` rank-4 operand plans, and the output preserves sparsity (stored count = the exact product support).

The generic rank >= 5 statistics path (subset enumeration) is a separate concern and not touched here.
